### PR TITLE
[Schema Update] Add a flag to indicate if and article is live

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -101,6 +101,7 @@ message Article {
     optional string google_podcast_url = 19;
     optional string spotify_podcast_url = 20;
     repeated Video videos = 21;
+    optional bool isLive = 22;
 }
 
 message Card {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a new flag to the Article that controls the display of the flashing dot before the kicker. This is equivalent to the `showLiveIndicator` flag currently used in the old Collection response.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

This can be tested by observing the flash dot on cards with this flag set to true. 
