### PR TITLE
Add `renderedItem` to schema

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -79,6 +79,11 @@ message Branding {
     string about_uri = 6;
 }
 
+message RenderingPlatformSupport {
+    string minBridgetVersion = 1;
+    string uri = 2;
+}
+
 message Article {
     string id = 1;
     string title = 6;
@@ -103,6 +108,8 @@ message Article {
     optional string pocket_cast_podcast_url = 23;
     repeated Video videos = 21;
     optional bool isLive = 22;
+    optional RenderingPlatformSupport renderedItemProd = 24;
+    optional RenderingPlatformSupport renderedItemBeta = 24;    
 }
 
 message Card {

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -109,7 +109,7 @@ message Article {
     repeated Video videos = 21;
     optional bool isLive = 22;
     optional RenderingPlatformSupport renderedItemProd = 24;
-    optional RenderingPlatformSupport renderedItemBeta = 24;    
+    optional RenderingPlatformSupport renderedItemBeta = 25;    
 }
 
 message Card {


### PR DESCRIPTION
Paired with @silvacb 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

 We want to include an optional `renderedItemUrl` for every item in the blueprint response. This PR adds that field - one for prod, one for beta. See [this ticket](https://theguardian.atlassian.net/browse/LIVE-5214).

