### PR TITLE
Making the prefered_number_of_column required

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -145,7 +145,7 @@ message Row {
     repeated Column columns = 1;
     optional Palette palette_light = 2;
     optional Palette palette_dark = 3;
-    optional int32 preferred_number_of_columns = 4;
+    int32 preferred_number_of_columns = 4;
     optional Thrasher thrasher = 5;
 }
 


### PR DESCRIPTION
## What does this change?
The field `preferred_number_of_columns` should always provide a numeric value, having it optional make two problems on the client side:

- it generates nullable field which cause more code to write to deal with null safety
- client also assume a number if it is null (currently ios assumes it is 4 and android 2), not consistent!

This PR makes it mandatory so client doesn't have to do any of the above two things.
