### PR TITLE
[Schema update] Add paid content flag to Card

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -125,6 +125,7 @@ message Card {
     optional bool compact = 4;
     repeated Article sublinks = 5;
     optional string htmlFallback = 6;
+    optional bool paidContent = 7;
 }
 
 message Column {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an optional `paidContent` flag to the Card object as part of the work to support paid content cards in the blueprint schema.
