### PR TITLE
[Schema update] Add branding field to card instead of paid Content

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -125,7 +125,7 @@ message Card {
     optional bool compact = 4;
     repeated Article sublinks = 5;
     optional string htmlFallback = 6;
-    optional bool paidContent = 7;
+    optional Branding branding = 7;
 }
 
 message Column {


### PR DESCRIPTION
We've previously added a `branding` field at the Collection level, but we also need to handle the cases where we have branded cards not inside a branded container. This PR adds a branding field to the Card object (repurposing the `paidContent` field as this change had not been released in Maven).