### PR TITLE
Add premiumContent flag on container and card levels

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -126,6 +126,7 @@ message Card {
     repeated Article sublinks = 5;
     optional string htmlFallback = 6;
     optional bool paidContent = 7;
+    optional bool premiumContent = 8;
 }
 
 message Column {
@@ -157,4 +158,5 @@ message Collection {
     optional Palette palette_light = 2;
     optional Palette palette_dark = 3;
     optional Branding branding = 6;
+    optional bool premiumContent = 7;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a boolean flag `premiumContent` to the `Collection` and `Card` models to indicate the premium container and premium cards (i.e. the crosswords).

Currently, only premium users are allowed to open the crossword container.  Non paid users see the yellow "Support the Guardian" popup screen if they click the header of the container.

Similarly, only premium users are allowed to open the crossword card.  A separate `premiumContent` flag is added to the card because it was found that _regular_ containers may contain crossword cards (for example, the `Puzzles` container inside `Lifestyle` front contains crossword cards).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

A snapshot version was released to sonatype and we see the new fields in the model.