### PR TITLE
Make height and width optional and remove orientation

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -39,13 +39,13 @@ enum MediaType {
 }
 
 message Image {
+    reserved 5
     optional string alt_text = 1;
     optional string caption = 2;
     optional string credit = 3;
-    int32 height = 4;
-    string orientation = 5;
+    optional int32 height = 4;
     string url_template = 6;
-    int32 width = 7;
+    optional int32 width = 7;
 }
 
 message Video {

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -39,7 +39,6 @@ enum MediaType {
 }
 
 message Image {
-    reserved 5
     optional string alt_text = 1;
     optional string caption = 2;
     optional string credit = 3;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

See [this ticket](https://theguardian.atlassian.net/browse/LIVE-5237)

I asked @guardian-ben if we need to provide width/height/orientation. 

”I don't think we do anymore. Alex Breuer changed to a fixed aspect ratio for all images that are hard-coded locally. However, I think we should keep them  but make them optional (except orientation, which can be deleted and calculated locally) in case we want a new card that shows the full image in the future” 

This PR ensures the correct change to the schema