### PR TITLE
Add follow up data to collections

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -154,6 +154,17 @@ message Row {
     optional Thrasher thrasher = 5;
 }
 
+message FollowUp {
+    enum FollowUpType {
+        FOLLOW_UP_TYPE_LIST = 0;
+        FOLLOW_UP_TYPE_FRONT = 1;
+        FOLLOW_UP_TYPE_INAPP = 2;
+    }
+    FollowUpType type = 0;
+    string uri = 1;
+    optional string blueprint_uri = 2;
+}
+
 message Collection {
     string id = 1;
     optional string title = 5;
@@ -162,4 +173,5 @@ message Collection {
     optional Palette palette_dark = 3;
     optional Branding branding = 6;
     optional bool premium_content = 7;
+    FollowUp followup = 8;
 }

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -173,5 +173,5 @@ message Collection {
     optional Palette palette_dark = 3;
     optional Branding branding = 6;
     optional bool premium_content = 7;
-    FollowUp follow_up = 8;
+    optional FollowUp follow_up = 8;
 }

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -160,9 +160,9 @@ message FollowUp {
         FOLLOW_UP_TYPE_FRONT = 1;
         FOLLOW_UP_TYPE_INAPP = 2;
     }
-    FollowUpType type = 0;
-    string uri = 1;
-    optional string blueprint_uri = 2;
+    FollowUpType type = 1;
+    string uri = 2;
+    optional string blueprint_uri = 3;
 }
 
 message Collection {

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -173,5 +173,5 @@ message Collection {
     optional Palette palette_dark = 3;
     optional Branding branding = 6;
     optional bool premium_content = 7;
-    FollowUp followup = 8;
+    FollowUp follow_up = 8;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR defines the message format for follow up data and add it to the `Collection` message in MAPI data model.

The follow-up data is intended to provide a URI for the native app to show more content, for example, when users click the collection title.

The follow-up link has three possible types:
1. `Front` URL - which brings users to another front
2. `List` URL - it may either be a list from the collection or from a tag it is associated with
3. 'InApp` - a in-app deep link.  Currently the crossword container provides an in-app deep link for the follow-up link

The message has a `uri` which serve responses in the current JSON format.  The optional `blueprint_uri` provides the link which serve responses in the new blueprint format if it is available.
