### PR TITLE
Lint proto files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+
+jobs:
+  lint_proto_files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint proto files
+        run: |
+          brew install protolint
+          protolint ./proto/.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   lint_proto_files:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get protolint
+        run: brew install protolint
+
       - name: Lint proto files
-        run: |
-          brew install protolint
-          protolint ./proto/.
+        run: protolint ./proto/.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 These models are used to communicate between MAPI and the native apps.
 This repository defines the protobuf [schema](./proto/collection.proto) for "blueprint" collections.
 
+## Linting
+
+[Protolint](https://github.com/yoheimuta/protolint) is used to lint the proto files in this repository.
+Protolint follows the official Google [style guide](https://protobuf.dev/programming-guides/style/).
+
+If the proto file isn't linted correctly status checks on a PR will fail.
+
+To fix any lint errors:
+
+```
+brew install protolint
+protolint -fix ./proto/.
+```
+
 ## Releases
 
 Use the GitHub UI to generate schema releases.

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -1,177 +1,178 @@
 // collection.proto
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/duration.proto";
-
 package com.gu.mobile.mapi.models;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
 option swift_prefix="Blueprint";
 
 message Palette {
-    string accent_colour = 1;
-    string background = 2;
-    string comment_count = 3;
-    string element_background = 4;
-    string headline = 5;
-    string immersive_kicker = 6;
-    string main = 7;
-    string media_background = 8;
-    string media_icon = 9;
-    string meta_text = 10;
-    string pill = 11;
-    string pillar = 12;
-    string secondary = 13;
-    string shadow = 14;
-    string top_border = 15;
+  string accent_colour = 1;
+  string background = 2;
+  string comment_count = 3;
+  string element_background = 4;
+  string headline = 5;
+  string immersive_kicker = 6;
+  string main = 7;
+  string media_background = 8;
+  string media_icon = 9;
+  string meta_text = 10;
+  string pill = 11;
+  string pillar = 12;
+  string secondary = 13;
+  string shadow = 14;
+  string top_border = 15;
 }
 
 message Links {
-    string related_uri = 1;
-    string short_url = 2;
-    string uri = 3;
-    string web_uri = 4;
+  string related_uri = 1;
+  string short_url = 2;
+  string uri = 3;
+  string web_uri = 4;
 }
 
 enum MediaType {
-    MEDIA_TYPE_VIDEO = 0;
-    MEDIA_TYPE_AUDIO = 1;
-    MEDIA_TYPE_IMAGE = 2;
+  MEDIA_TYPE_VIDEO_UNSPECIFIED = 0;
+  MEDIA_TYPE_AUDIO = 1;
+  MEDIA_TYPE_IMAGE = 2;
 }
 
 message Image {
-    optional string alt_text = 1;
-    optional string caption = 2;
-    optional string credit = 3;
-    optional int32 height = 4;
-    string url_template = 6;
-    optional int32 width = 7;
+  optional string alt_text = 1;
+  optional string caption = 2;
+  optional string credit = 3;
+  optional int32 height = 4;
+  string url_template = 6;
+  optional int32 width = 7;
 }
 
 message Video {
-    optional string alt_text = 1;
-    optional string caption = 2;
-    optional string credit = 3;
-    optional int32 height = 4;
-    optional string orientation = 5;
-    string url = 6;
-    optional int32 width = 7;
+  optional string alt_text = 1;
+  optional string caption = 2;
+  optional string credit = 3;
+  optional int32 height = 4;
+  optional string orientation = 5;
+  string url = 6;
+  optional int32 width = 7;
 }
 
 message LiveEvent {
-    string id = 1;
-    string title = 2;
-    string body = 3;
-    optional google.protobuf.Timestamp published_date = 4;
-    optional google.protobuf.Timestamp last_updated_date = 5;
+  string id = 1;
+  string title = 2;
+  string body = 3;
+  optional google.protobuf.Timestamp published_date = 4;
+  optional google.protobuf.Timestamp last_updated_date = 5;
 }
 
 message Thrasher {
-    string uri = 1;
+  string uri = 1;
 }
 
 message Branding {
-    string branding_type = 1;
-    string sponsor_name = 2;
-    string logo = 3;
-    string sponsor_uri = 4;
-    string label = 5;
-    string about_uri = 6;
+  string branding_type = 1;
+  string sponsor_name = 2;
+  string logo = 3;
+  string sponsor_uri = 4;
+  string label = 5;
+  string about_uri = 6;
 }
 
 message RenderingPlatformSupport {
-    string min_bridget_version = 1;
-    string uri = 2;
+  string min_bridget_version = 1;
+  string uri = 2;
 }
 
 message Article {
-    string id = 1;
-    optional string byline = 2;
-    repeated Image images = 3;
-    Links links = 4;
-    optional string kicker = 5;
-    string title = 6;
-    optional string trail_text = 7;
-    optional int32 rating = 8;
-    optional int32 comment_count = 9;
-    optional google.protobuf.Timestamp published_date = 10;
-    optional google.protobuf.Timestamp last_updated_date = 11;
-    optional MediaType media_type = 12;
-    optional google.protobuf.Duration duration = 13;
-    optional Image profile_image = 14;
-    repeated LiveEvent events = 15;
-    optional Palette palette_light = 16;
-    optional Palette palette_dark = 17;
-    optional string apple_podcast_url = 18;
-    optional string google_podcast_url = 19;
-    optional string spotify_podcast_url = 20;
-    repeated Video videos = 21;
-    optional bool is_live = 22;
-    optional string pocket_cast_podcast_url = 23;
-    optional RenderingPlatformSupport rendered_item_prod = 24;
-    optional RenderingPlatformSupport rendered_item_beta = 25;
+  string id = 1;
+  optional string byline = 2;
+  repeated Image images = 3;
+  Links links = 4;
+  optional string kicker = 5;
+  string title = 6;
+  optional string trail_text = 7;
+  optional int32 rating = 8;
+  optional int32 comment_count = 9;
+  optional google.protobuf.Timestamp published_date = 10;
+  optional google.protobuf.Timestamp last_updated_date = 11;
+  optional MediaType media_type = 12;
+  optional google.protobuf.Duration duration = 13;
+  optional Image profile_image = 14;
+  repeated LiveEvent events = 15;
+  optional Palette palette_light = 16;
+  optional Palette palette_dark = 17;
+  optional string apple_podcast_url = 18;
+  optional string google_podcast_url = 19;
+  optional string spotify_podcast_url = 20;
+  repeated Video videos = 21;
+  optional bool is_live = 22;
+  optional string pocket_cast_podcast_url = 23;
+  optional RenderingPlatformSupport rendered_item_prod = 24;
+  optional RenderingPlatformSupport rendered_item_beta = 25;
 }
 
 message Card {
-    enum CardType {
-        CARD_TYPE_ARTICLE = 0;
-        CARD_TYPE_PODCAST = 1;
-        CARD_TYPE_VIDEO = 2;
-        CARD_TYPE_CROSSWORD = 3;
-        CARD_TYPE_DISPLAY = 4;
-        CARD_TYPE_MOSTVIEWED = 5;
-    }
-    CardType type = 1;
-    Article article = 2;
-    optional bool boosted = 3;
-    optional bool compact = 4;
-    repeated Article sublinks = 5;
-    optional string html_fallback = 6;
-    optional Branding branding = 7;
-    optional bool premium_content = 8;
-    optional Palette sublinks_palette_light = 9;
-    optional Palette sublinks_palette_dark = 10;
+  enum CardType {
+    CARD_TYPE_ARTICLE_UNSPECIFIED = 0;
+    CARD_TYPE_PODCAST = 1;
+    CARD_TYPE_VIDEO = 2;
+    CARD_TYPE_CROSSWORD = 3;
+    CARD_TYPE_DISPLAY = 4;
+    CARD_TYPE_MOSTVIEWED = 5;
+  }
+  CardType type = 1;
+  Article article = 2;
+  optional bool boosted = 3;
+  optional bool compact = 4;
+  repeated Article sublinks = 5;
+  optional string html_fallback = 6;
+  optional Branding branding = 7;
+  optional bool premium_content = 8;
+  optional Palette sublinks_palette_light = 9;
+  optional Palette sublinks_palette_dark = 10;
 }
 
 message Column {
-    repeated Card cards = 1;
-    optional Palette palette_light = 2;
-    optional Palette palette_dark = 3;
-    int32 preferred_width = 4;
+  repeated Card cards = 1;
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  int32 preferred_width = 4;
 }
 
 message Row {
-    enum RowType {
-        ROW_TYPE_LAYOUT = 0;
-        ROW_TYPE_CAROUSEL = 1;
-        ROW_TYPE_THRASHER = 2;
-    }
-    repeated Column columns = 1;
-    optional Palette palette_light = 2;
-    optional Palette palette_dark = 3;
-    int32 preferred_number_of_columns = 4;
-    optional Thrasher thrasher = 5;
-    RowType type = 6;
-    optional string title = 7;
+  enum RowType {
+    ROW_TYPE_LAYOUT_UNSPECIFIED = 0;
+    ROW_TYPE_CAROUSEL = 1;
+    ROW_TYPE_THRASHER = 2;
+  }
+  repeated Column columns = 1;
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  int32 preferred_number_of_columns = 4;
+  optional Thrasher thrasher = 5;
+  RowType type = 6;
+  optional string title = 7;
 }
 
 message FollowUp {
-    enum FollowUpType {
-        FOLLOW_UP_TYPE_LIST = 0;
-        FOLLOW_UP_TYPE_FRONT = 1;
-        FOLLOW_UP_TYPE_INAPP = 2;
-    }
-    FollowUpType type = 1;
-    string uri = 2;
-    optional string blueprint_uri = 3;
+  enum FollowUpType {
+    FOLLOW_UP_TYPE_LIST_UNSPECIFIED = 0;
+    FOLLOW_UP_TYPE_FRONT = 1;
+    FOLLOW_UP_TYPE_INAPP = 2;
+  }
+  FollowUpType type = 1;
+  string uri = 2;
+  optional string blueprint_uri = 3;
 }
 
 message Collection {
-    string id = 1;
-    optional Palette palette_light = 2;
-    optional Palette palette_dark = 3;
-    repeated Row rows = 4;
-    optional string title = 5;
-    optional Branding branding = 6;
-    optional bool premium_content = 7;
-    optional FollowUp follow_up = 8;
+  string id = 1;
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  repeated Row rows = 4;
+  optional string title = 5;
+  optional Branding branding = 6;
+  optional bool premium_content = 7;
+  optional FollowUp follow_up = 8;
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -8,7 +8,7 @@
             "name": "MediaType",
             "enum_fields": [
               {
-                "name": "MEDIA_TYPE_VIDEO"
+                "name": "MEDIA_TYPE_VIDEO_UNSPECIFIED"
               },
               {
                 "name": "MEDIA_TYPE_AUDIO",
@@ -24,7 +24,7 @@
             "name": "Card.CardType",
             "enum_fields": [
               {
-                "name": "CARD_TYPE_ARTICLE"
+                "name": "CARD_TYPE_ARTICLE_UNSPECIFIED"
               },
               {
                 "name": "CARD_TYPE_PODCAST",
@@ -52,7 +52,7 @@
             "name": "Row.RowType",
             "enum_fields": [
               {
-                "name": "ROW_TYPE_LAYOUT"
+                "name": "ROW_TYPE_LAYOUT_UNSPECIFIED"
               },
               {
                 "name": "ROW_TYPE_CAROUSEL",
@@ -68,7 +68,7 @@
             "name": "FollowUp.FollowUpType",
             "enum_fields": [
               {
-                "name": "FOLLOW_UP_TYPE_LIST"
+                "name": "FOLLOW_UP_TYPE_LIST_UNSPECIFIED"
               },
               {
                 "name": "FOLLOW_UP_TYPE_FRONT",
@@ -729,10 +729,10 @@
         ],
         "imports": [
           {
-            "path": "google/protobuf/timestamp.proto"
+            "path": "google/protobuf/duration.proto"
           },
           {
-            "path": "google/protobuf/duration.proto"
+            "path": "google/protobuf/timestamp.proto"
           }
         ],
         "package": {


### PR DESCRIPTION
## What does this change?

This PR adds a lint status check on PRs. We recently made some retrospective changes ([1](https://github.com/guardian/mobile-apps-api-models/pull/19), [2](https://github.com/guardian/mobile-apps-api-models/pull/20)) to the proto file to update the formatting. This status check will help to continually keep the proto file in accordance with Google's [style guide](https://protobuf.dev/programming-guides/style/).

I've also added instructions to the readme explaining how to install/lint the proto files manually.

## How to test

The lint check is triggered on pull request events. After raising this PR I validated:
- the lint workflow was executed
- the workflow [failed](https://github.com/guardian/mobile-apps-api-models/actions/runs/5410334798) because of lint errors
- after fixing the errors locally (`protolint -fix ./proto/.`) and pushing my changes the corresponding run was [successful](https://github.com/guardian/mobile-apps-api-models/actions/runs/5410348904)

Note that both running the workflow and executing the lint command locally returns information about any lint errors. For example, in this trivial example I updated the accent colour to camel case:

<img width="338" alt="Screenshot 2023-06-29 at 10 16 27" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/3eb8efc9-4eec-4c2a-ba63-43428f699445">

And when running the lint command we see:

<img width="898" alt="Screenshot 2023-06-29 at 10 15 50" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/0aa3b537-c99a-4f31-8526-e676b419f528">

Using the fix command (`protolint -fix ./proto/.`) changes the field name back to snake case.
