### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="https://img.shields.io/github/v/release/guardian/mobile-apps-api-models?label=schema%20version">
-<img src="https://img.shields.io/maven-central/v/com.gu/mobile-apps-api-models_2.12?label=scala%202.12">
+
+[![mobile-apps-api-models Scala version support](https://index.scala-lang.org/guardian/mobile-apps-api-models/mobile-apps-api-models/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/mobile-apps-api-models/mobile-apps-api-models)
 
 # Mobile Apps Api Models
 


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `mobile-apps-api-models` (and what the latest `mobile-apps-api-models` version is for each of those Scala versions):

[![mobile-apps-api-models Scala version support](https://index.scala-lang.org/guardian/mobile-apps-api-models/mobile-apps-api-models/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/mobile-apps-api-models/mobile-apps-api-models)

At the moment, `mobile-apps-api-models` only supports Scala 2.12, but when you come to add Scala 2.13 support, the badge will update automatically. More details on the badge format: scalacenter/scaladex#660
