### PR TITLE
Cross compile for scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val scalaModels = project.in(file("."))
     ),
 
     Compile / PB.protoSources := Seq(baseDirectory.value / "./proto"),
-    releaseCrossBuild := true
+    releaseCrossBuild := true,
     releaseProcess := {
       val process = Seq[ReleaseStep](
         checkSnapshotDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
 import ReleaseTransformations._
 
 ThisBuild / organization := "com.gu"
-ThisBuild / scalaVersion := "2.12.17"
+ThisBuild / scalaVersion := "2.13.11"
 ThisBuild / licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+
+crossScalaVersions := Seq(scalaVersion.value, "2.12.18")
 
 lazy val scalaModels = project.in(file("."))
   .settings(
@@ -17,7 +19,7 @@ lazy val scalaModels = project.in(file("."))
     ),
 
     Compile / PB.protoSources := Seq(baseDirectory.value / "./proto"),
-
+    releaseCrossBuild := true
     releaseProcess := {
       val process = Seq[ReleaseStep](
         checkSnapshotDependencies,
@@ -25,7 +27,7 @@ lazy val scalaModels = project.in(file("."))
         runClean,
         runTest,
         setReleaseVersion,
-        releaseStepCommand("publishSigned"),
+        releaseStepCommand("+publishSigned"),
       )
 
       if (!isSnapshot.value) {


### PR DESCRIPTION
## What does this change?

This cross compiles the scala models for scala version 2.13. We need 2.13 versions of the models before upgrading MAPI to version 2.13.

## How to test

I released a [snapshot](https://github.com/guardian/mobile-apps-api-models/actions/runs/5485832033/jobs/9995128192) of the library successfully and found both the [2.12](https://oss.sonatype.org/content/repositories/snapshots/com/gu/mobile-apps-api-models_2.12/0.0.14.5-SNAPSHOT/) and [2.13](https://oss.sonatype.org/content/repositories/snapshots/com/gu/mobile-apps-api-models_2.13/0.0.14.5-SNAPSHOT/) models on sonatype.
