### PR TITLE
Update build dependencies

### DIFF
--- a/.github/workflows/release-scala-models.yml
+++ b/.github/workflows/release-scala-models.yml
@@ -1,4 +1,4 @@
-name: Release Snapshot to Sonatype
+name: Release to Sonatype
 
 on:
   release:

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val scalaModels = project.in(file("."))
         runClean,
         runTest,
         setReleaseVersion,
-        releaseStepCommand("+publishSigned"),
+        releaseStepCommandAndRemaining("+publishSigned"),
       )
 
       if (!isSnapshot.value) {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.5")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"


### PR DESCRIPTION
## What does this change?

Following #26 I attempting to release the scala models but there was an [error](https://github.com/guardian/mobile-apps-api-models/actions/runs/5485884934). This change updates the project dependencies to the latest and updates the penultimate build step in accordance with sbt-sonatype's suggested [steps](https://github.com/xerial/sbt-sonatype#using-with-sbt-release-plugin).

## How to test

Given there were no schema changes, and given the error didn't impact snapshot releases, I created a new [release](https://github.com/guardian/mobile-apps-api-models/releases/tag/v0.0.16) targeting this development branch and then confirmed the corresponding [action](https://github.com/guardian/mobile-apps-api-models/actions/runs/5487623688) was successful and that we could find the releases in [maven](https://repo1.maven.org/maven2/com/gu/).

