### PR TITLE
Namespace blueprint models according to current major version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq(scalaVersion.value, "2.12.18", "3.3.0")
 
 lazy val scalaModels = project.in(file("."))
   .settings(
-    name := "mobile-apps-api-models",
+    name := "mobile-apps-api-models-v0",
 
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -1,7 +1,7 @@
 // collection.proto
 syntax = "proto3";
 
-package com.gu.mobile.mapi.models;
+package com.gu.mobile.mapi.models.v0;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -752,7 +752,7 @@
           }
         ],
         "package": {
-          "name": "com.gu.mobile.mapi.models"
+          "name": "com.gu.mobile.mapi.models.v0"
         },
         "options": [
           {


### PR DESCRIPTION
## What does this change?

This namespaces the blueprint model according to the current major version. For the future, when we introduce a breaking change, the documented [process](https://github.com/guardian/mobile-apps-api/pull/2640) also indicates that we need to update the package name and project name to ensure the artifact has the expected namespace.

For now the major version is 0 - before the first production release we'll create a version 1 of the schema.

When this change has been merged and released to maven I'll create a corresponding PR in MAPI to update the models.

## How to test

I created a snapshot [release](https://github.com/guardian/mobile-apps-api-models/releases/tag/v0.0.17.4-SNAPSHOT) for this branch. The [action](https://github.com/guardian/mobile-apps-api-models/actions/runs/5670572799) was successful:
<img width="1184" alt="Screenshot 2023-07-26 at 17 32 33" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/114eaedd-4d0e-41ed-a597-15e4c014d8a3">

The version could be found on [sonatype](https://oss.sonatype.org/content/repositories/snapshots/com/gu/mobile-apps-api-models-v0_2.13/0.0.17.4-SNAPSHOT/) with the expected artifact name (note the "-v0" in the artifact name):

<img width="1496" alt="Screenshot 2023-07-26 at 17 33 23" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/d2154140-6981-409f-b1a1-0d4919eae383">

This version can be successfully introduced into MAPI:

<img width="785" alt="Screenshot 2023-07-26 at 17 53 28" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/4736af6e-d12d-46ad-9660-e0371afff797">



