### PR TITLE
Add show quoted headline field to article object

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -177,6 +177,8 @@ message Card {
   optional bool premium_content = 8;
   optional Palette sublinks_palette_light = 9;
   optional Palette sublinks_palette_dark = 10;
+  // Quoted headline shown for a card if selected in the fronts tool.
+  optional bool show_quoted_headline = 11;
 }
 
 message Column {

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -133,6 +133,8 @@ message Article {
   optional string pocket_cast_podcast_url = 23;
   optional RenderingPlatformSupport rendered_item_prod = 24;
   optional RenderingPlatformSupport rendered_item_beta = 25;
+  // Quoted headline shown for a card if selected in the fronts tool.
+  optional bool show_quoted_headline = 26;
 }
 
 message Card {
@@ -177,8 +179,6 @@ message Card {
   optional bool premium_content = 8;
   optional Palette sublinks_palette_light = 9;
   optional Palette sublinks_palette_dark = 10;
-  // Quoted headline shown for a card if selected in the fronts tool.
-  optional bool show_quoted_headline = 11;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -530,6 +530,12 @@
                 "name": "rendered_item_beta",
                 "type": "RenderingPlatformSupport",
                 "optional": true
+              },
+              {
+                "id": 26,
+                "name": "show_quoted_headline",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -592,12 +598,6 @@
                 "id": 10,
                 "name": "sublinks_palette_dark",
                 "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 11,
-                "name": "show_quoted_headline",
-                "type": "bool",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -593,6 +593,12 @@
                 "name": "sublinks_palette_dark",
                 "type": "Palette",
                 "optional": true
+              },
+              {
+                "id": 11,
+                "name": "show_quoted_headline",
+                "type": "bool",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
## What does this change?

In the fronts tool, the card configuration allows editors to choose whether a card’s headline should be quoted. On web and prod app, if this toggle is selected then the headline should appear in quotes.

We need to make sure this behaviour is the same on blueprint fronts by including an additional boolean field in the schema to represent article configuration: `show_quoted_headline`.

MAPI should be returning this field in accordance with the data we get from the fronts tool and the client should be using the boolean property to determine when to show quoted headline.