### PR TITLE
Add an empty card type

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -148,6 +148,11 @@ message Card {
      */
     CARD_TYPE_DISPLAY = 5;
     CARD_TYPE_MOSTVIEWED = 6;
+    /**
+    * An empty card is used to indicate an empty space so that the native
+    * client do not stretch the previous card to occupy the space
+    */  
+    CARD_TYPE_EMPTY = 7;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -53,6 +53,10 @@
               {
                 "name": "CARD_TYPE_MOSTVIEWED",
                 "integer": 6
+              },
+              {
+                "name": "CARD_TYPE_EMPTY",
+                "integer": 7
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We see that on a carousel row with 2 cards in each column, if we have an odd number of cards resulting in a single card only in the last column, this card is stretched to fit the whole column.  What we expect is to keep all the cards the same size and just leave the empty space there.

One solution we are going to implement is to indicate in the blueprint response that there is empty space where a card would be.

The PR is to add to the schema a new card type `EMPTY_CARD_TYPE` so that we are able to indicate where to leave the space (the same size as a card) empty in the layout.  

