### PR TITLE
Add list object and separate proto files

### DIFF
--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -5,243 +5,10 @@ package com.gu.mobile.mapi.models.v0;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "shared.proto";  
 
 option swift_prefix="Blueprint";
 
-message Palette {
-  string accent_colour = 1;
-  string background = 2;
-  string comment_count = 3;
-  string element_background = 4;
-  string headline = 5;
-  string immersive_kicker = 6;
-  string main = 7;
-  string media_background = 8;
-  string media_icon = 9;
-  string meta_text = 10;
-  string pill = 11;
-  string pillar = 12;
-  string secondary = 13;
-  string shadow = 14;
-  string top_border = 15;
-}
-
-message Links {
-  string related_uri = 1;
-  string short_url = 2;
-  string uri = 3;
-  string web_uri = 4;
-}
-
-enum MediaType {
-  MEDIA_TYPE_UNSPECIFIED = 0;
-  MEDIA_TYPE_VIDEO = 1;
-  MEDIA_TYPE_AUDIO = 2;
-  MEDIA_TYPE_IMAGE = 3;
-}
-
-message Image {
-  optional string alt_text = 1;
-  optional string caption = 2;
-  optional string credit = 3;
-  optional int32 height = 4;
-  string url_template = 6;
-  optional int32 width = 7;
-}
-
-message Video {
-  optional string alt_text = 1;
-  optional string caption = 2;
-  optional string credit = 3;
-  optional int32 height = 4;
-  optional string orientation = 5;
-  string url = 6;
-  optional int32 width = 7;
-}
-
-// This message is only applicable to live blogs.
-message LiveEvent {
-  string id = 1;
-  string title = 2;
-  string body = 3;
-  optional google.protobuf.Timestamp published_date = 4;
-  optional google.protobuf.Timestamp last_updated_date = 5;
-}
-
-/**
- * This is a special type of container on a front that is delivered via
- * editorial tools.Thrashers are used to promote either features or
- * commercial content.
- */
-message Thrasher {
-  string uri = 1;
-}
-
-message Branding {
-  string branding_type = 1;
-  string sponsor_name = 2;
-  string logo = 3;
-  string sponsor_uri = 4;
-  string label = 5;
-  string about_uri = 6;
-}
-
-/**
- * The rendering platform support object is required to support opening AR
- * articles on native clients.We don't return this message if the corresponding
- * article cannot be rendered by the server (instead only by legacy article
- * templates).
- */
-message RenderingPlatformSupport {
-  string min_bridget_version = 1;
-  string uri = 2;
-}
-
-message Article {
-  string id = 1;
-  optional string byline = 2;
-  repeated Image images = 3;
-  Links links = 4;
-  optional string kicker = 5;
-  string title = 6;
-  optional string trail_text = 7;
-  optional int32 rating = 8;
-  optional int32 comment_count = 9;
-  optional google.protobuf.Timestamp published_date = 10;
-  optional google.protobuf.Timestamp last_updated_date = 11;
-  optional MediaType media_type = 12;
-  // Only expected for video or audio content.
-  optional google.protobuf.Duration duration = 13;
-  // MAPI will never return both images and a profile_image.
-  optional Image profile_image = 14;
-  repeated LiveEvent events = 15;
-  optional Palette palette_light = 16;
-  optional Palette palette_dark = 17;
-  // Only applicable to podcasts.
-  optional string apple_podcast_url = 18;
-  // Only applicable to podcasts.
-  optional string google_podcast_url = 19;
-  // Only applicable to podcasts.
-  optional string spotify_podcast_url = 20;
-  repeated Video videos = 21;
-  /**
-   * This is an indicator as to whether a live blog is still blogging, or if
-   * it's been closed.
-   */
-  optional bool is_live = 22;
-  // Only applicable to podcasts.
-  optional string pocket_cast_podcast_url = 23;
-  optional RenderingPlatformSupport rendered_item_prod = 24;
-  optional RenderingPlatformSupport rendered_item_beta = 25;
-  // Quoted headline shown for a card if selected in the fronts tool.
-  optional bool show_quoted_headline = 26;
-}
-
-message Card {
-  enum CardType {
-    CARD_TYPE_UNSPECIFIED = 0;
-    CARD_TYPE_ARTICLE = 1;
-    CARD_TYPE_PODCAST = 2;
-    CARD_TYPE_VIDEO = 3;
-    CARD_TYPE_CROSSWORD = 4;
-    /**
-     * Display cards have their own separate design (see figma designs for
-     * ref).
-     */
-    CARD_TYPE_DISPLAY = 5;
-    CARD_TYPE_MOSTVIEWED = 6;
-    /**
-    * An empty card is used to indicate an empty space so that the native
-    * client do not stretch the previous card to occupy the space
-    */  
-    CARD_TYPE_EMPTY = 7;
-  }
-  CardType type = 1;
-  Article article = 2;
-  /**
-   * Boosted cards show a boosted headline size and a main image that spans
-   * full width on mobile.
-   */
-  optional bool boosted = 3;
-  /**
-   * Compact cards don't show all the information that non-compact cards do,
-   * and tend to appear in a carousel.
-   */
-  optional bool compact = 4;
-  repeated Article sublinks = 5;
-  optional string html_fallback = 6;
-  /**
-   * Individual cards can be branded and not be part of a branded container.
-   * Cards that are branded tend to show the sponsor logo and should be
-   * returned with a different palette.
-   */
-  optional Branding branding = 7;
-  /**
-   * Individual cards can be defined as "premium content". If premium_content
-   * is true then it implies the card should be hidden from signed-in users,
-   * for example if the card has been paid for by an external sponsor.
-   */
-  optional bool premium_content = 8;
-  optional Palette sublinks_palette_light = 9;
-  optional Palette sublinks_palette_dark = 10;
-}
-
-message Column {
-  /**
-   * By default, if there are multiple cards in the cards array then it's
-   * expected the client will display these as stacked vertical elements.
-   */
-  repeated Card cards = 1;
-  optional Palette palette_light = 2;
-  optional Palette palette_dark = 3;
-  // The card(s) in the column assume this preferred width.
-  int32 preferred_width = 4;
-}
-
-message Row {
-  enum RowType {
-    ROW_TYPE_UNSPECIFIED = 0;
-    // Layout is the "default" way of laying out rows and columns.
-    ROW_TYPE_LAYOUT = 1;
-    ROW_TYPE_CAROUSEL = 2;
-    ROW_TYPE_THRASHER = 3;
-  }
-  repeated Column columns = 1;
-  optional Palette palette_light = 2;
-  optional Palette palette_dark = 3;
-  /**
-   * Tablet devices support a 4 column display, whereas mobile devices
-   * support a 2 column display. If a mobile device receives a row with a
-   * preferred number of columns greater than 2, the additional columns are
-   * "wrapped" onto an extra row (a bit like CSS flex-wrap).
-   */
-  int32 preferred_number_of_columns = 4;
-  optional Thrasher thrasher = 5;
-  RowType type = 6;
-  optional string title = 7;
-}
-
-/**
- * The follow up message contains links to get more information about the
- * collection.
- */
-message FollowUp {
-  enum FollowUpType {
-    FOLLOW_UP_TYPE_UNSPECIFIED = 0;
-    FOLLOW_UP_TYPE_LIST = 1;
-    FOLLOW_UP_TYPE_FRONT = 2;
-    FOLLOW_UP_TYPE_INAPP = 3;
-  }
-  FollowUpType type = 1;
-  string uri = 2;
-  /**
-   * At the time of creation MAPI couldn't support blueprint versions of the
-   * follow-on link so this field was marked as optional. As part of the
-   * migration work, MAPI will eventually support blueprint endpoints for all
-   * follow on links.
-   */
-  optional string blueprint_uri = 3;
-}
 
 message Collection {
   string id = 1;
@@ -278,8 +45,25 @@ message Collection {
   optional FollowUp follow_up = 8;
 }
 
-message List {
-  optional Branding branding = 1;
-  optional FollowUp follow_up = 2;
-  Collection collection = 3;
+
+/**
+ * The follow up message contains links to get more information about the
+ * collection.
+ */
+message FollowUp {
+  enum FollowUpType {
+    FOLLOW_UP_TYPE_UNSPECIFIED = 0;
+    FOLLOW_UP_TYPE_LIST = 1;
+    FOLLOW_UP_TYPE_FRONT = 2;
+    FOLLOW_UP_TYPE_INAPP = 3;
+  }
+  FollowUpType type = 1;
+  string uri = 2;
+  /**
+   * At the time of creation MAPI couldn't support blueprint versions of the
+   * follow-on link so this field was marked as optional. As part of the
+   * migration work, MAPI will eventually support blueprint endpoints for all
+   * follow on links.
+   */
+  optional string blueprint_uri = 3;
 }

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -3,12 +3,9 @@ syntax = "proto3";
 
 package com.gu.mobile.mapi.models.v0;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
 import "shared.proto";  
 
 option swift_prefix="Blueprint";
-
 
 message Collection {
   string id = 1;

--- a/proto/collection.proto
+++ b/proto/collection.proto
@@ -277,3 +277,9 @@ message Collection {
   optional bool premium_content = 7;
   optional FollowUp follow_up = 8;
 }
+
+message List {
+  optional Branding branding = 1;
+  optional FollowUp follow_up = 2;
+  Collection collection = 3;
+}

--- a/proto/list.proto
+++ b/proto/list.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package com.gu.mobile.mapi.models.v0;
+
+import "shared.proto";  
+
+message List {
+  optional Branding branding = 1;
+  optional string next_page = 2;
+  repeated Row rows = 4;
+  optional string title = 5;
+}

--- a/proto/list.proto
+++ b/proto/list.proto
@@ -4,6 +4,9 @@ package com.gu.mobile.mapi.models.v0;
 
 import "shared.proto";  
 
+option swift_prefix="Blueprint";
+
+
 message List {
   optional Branding branding = 1;
   optional string next_page = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -5,6 +5,136 @@
       "def": {
         "enums": [
           {
+            "name": "FollowUp.FollowUpType",
+            "enum_fields": [
+              {
+                "name": "FOLLOW_UP_TYPE_UNSPECIFIED"
+              },
+              {
+                "name": "FOLLOW_UP_TYPE_LIST",
+                "integer": 1
+              },
+              {
+                "name": "FOLLOW_UP_TYPE_FRONT",
+                "integer": 2
+              },
+              {
+                "name": "FOLLOW_UP_TYPE_INAPP",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Collection",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "palette_light",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "palette_dark",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "rows",
+                "type": "Row",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "branding",
+                "type": "Branding",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "premium_content",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "FollowUp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "FollowUpType"
+              },
+              {
+                "id": 2,
+                "name": "uri",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "blueprint_uri",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "google/protobuf/duration.proto"
+          },
+          {
+            "path": "google/protobuf/timestamp.proto"
+          },
+          {
+            "path": "shared.proto"
+          }
+        ],
+        "package": {
+          "name": "com.gu.mobile.mapi.models.v0"
+        },
+        "options": [
+          {
+            "name": "swift_prefix",
+            "value": "Blueprint"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "list.proto",
+      "def": {
+        "package": {
+          "name": "com.gu.mobile.mapi.models.v0"
+        }
+      }
+    },
+    {
+      "protopath": "shared.proto",
+      "def": {
+        "enums": [
+          {
             "name": "MediaType",
             "enum_fields": [
               {
@@ -76,26 +206,6 @@
               },
               {
                 "name": "ROW_TYPE_THRASHER",
-                "integer": 3
-              }
-            ]
-          },
-          {
-            "name": "FollowUp.FollowUpType",
-            "enum_fields": [
-              {
-                "name": "FOLLOW_UP_TYPE_UNSPECIFIED"
-              },
-              {
-                "name": "FOLLOW_UP_TYPE_LIST",
-                "integer": 1
-              },
-              {
-                "name": "FOLLOW_UP_TYPE_FRONT",
-                "integer": 2
-              },
-              {
-                "name": "FOLLOW_UP_TYPE_INAPP",
                 "integer": 3
               }
             ]
@@ -322,16 +432,6 @@
                 "name": "last_updated_date",
                 "type": "google.protobuf.Timestamp",
                 "optional": true
-              }
-            ]
-          },
-          {
-            "name": "Thrasher",
-            "fields": [
-              {
-                "id": 1,
-                "name": "uri",
-                "type": "string"
               }
             ]
           },
@@ -635,6 +735,16 @@
             ]
           },
           {
+            "name": "Thrasher",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uri",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "Row",
             "fields": [
               {
@@ -678,79 +788,6 @@
                 "optional": true
               }
             ]
-          },
-          {
-            "name": "FollowUp",
-            "fields": [
-              {
-                "id": 1,
-                "name": "type",
-                "type": "FollowUpType"
-              },
-              {
-                "id": 2,
-                "name": "uri",
-                "type": "string"
-              },
-              {
-                "id": 3,
-                "name": "blueprint_uri",
-                "type": "string",
-                "optional": true
-              }
-            ]
-          },
-          {
-            "name": "Collection",
-            "fields": [
-              {
-                "id": 1,
-                "name": "id",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "palette_light",
-                "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 3,
-                "name": "palette_dark",
-                "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 4,
-                "name": "rows",
-                "type": "Row",
-                "is_repeated": true
-              },
-              {
-                "id": 5,
-                "name": "title",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 6,
-                "name": "branding",
-                "type": "Branding",
-                "optional": true
-              },
-              {
-                "id": 7,
-                "name": "premium_content",
-                "type": "bool",
-                "optional": true
-              },
-              {
-                "id": 8,
-                "name": "follow_up",
-                "type": "FollowUp",
-                "optional": true
-              }
-            ]
           }
         ],
         "imports": [
@@ -763,13 +800,7 @@
         ],
         "package": {
           "name": "com.gu.mobile.mapi.models.v0"
-        },
-        "options": [
-          {
-            "name": "swift_prefix",
-            "value": "Blueprint"
-          }
-        ]
+        }
       }
     }
   ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -102,12 +102,6 @@
         ],
         "imports": [
           {
-            "path": "google/protobuf/duration.proto"
-          },
-          {
-            "path": "google/protobuf/timestamp.proto"
-          },
-          {
             "path": "shared.proto"
           }
         ],
@@ -163,7 +157,13 @@
         ],
         "package": {
           "name": "com.gu.mobile.mapi.models.v0"
-        }
+        },
+        "options": [
+          {
+            "name": "swift_prefix",
+            "value": "Blueprint"
+          }
+        ]
       }
     },
     {
@@ -824,14 +824,6 @@
                 "optional": true
               }
             ]
-          }
-        ],
-        "imports": [
-          {
-            "path": "google/protobuf/duration.proto"
-          },
-          {
-            "path": "google/protobuf/timestamp.proto"
           }
         ],
         "package": {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -826,6 +826,14 @@
             ]
           }
         ],
+        "imports": [
+          {
+            "path": "google/protobuf/duration.proto"
+          },
+          {
+            "path": "google/protobuf/timestamp.proto"
+          }
+        ],
         "package": {
           "name": "com.gu.mobile.mapi.models.v0"
         }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -125,6 +125,42 @@
     {
       "protopath": "list.proto",
       "def": {
+        "messages": [
+          {
+            "name": "List",
+            "fields": [
+              {
+                "id": 1,
+                "name": "branding",
+                "type": "Branding",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "next_page",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "rows",
+                "type": "Row",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "shared.proto"
+          }
+        ],
         "package": {
           "name": "com.gu.mobile.mapi.models.v0"
         }

--- a/proto/shared.proto
+++ b/proto/shared.proto
@@ -76,9 +76,9 @@ message Branding {
   
 /**
    * The rendering platform support object is required to support opening AR
-   * articles on native clients.We don't return this message if the corresponding
-   * article cannot be rendered by the server (instead only by legacy article
-   * templates).
+   * articles on native clients. We don't return this message if the 
+   * corresponding article cannot be rendered by the server (instead
+   *  only by legacy article templates).
    */
 message RenderingPlatformSupport {
   string min_bridget_version = 1;

--- a/proto/shared.proto
+++ b/proto/shared.proto
@@ -1,0 +1,220 @@
+syntax = "proto3";
+
+package com.gu.mobile.mapi.models.v0;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+message Palette {
+    string accent_colour = 1;
+    string background = 2;
+    string comment_count = 3;
+    string element_background = 4;
+    string headline = 5;
+    string immersive_kicker = 6;
+    string main = 7;
+    string media_background = 8;
+    string media_icon = 9;
+    string meta_text = 10;
+    string pill = 11;
+    string pillar = 12;
+    string secondary = 13;
+    string shadow = 14;
+    string top_border = 15;
+  }
+  
+  message Links {
+    string related_uri = 1;
+    string short_url = 2;
+    string uri = 3;
+    string web_uri = 4;
+  }
+  
+  enum MediaType {
+    MEDIA_TYPE_UNSPECIFIED = 0;
+    MEDIA_TYPE_VIDEO = 1;
+    MEDIA_TYPE_AUDIO = 2;
+    MEDIA_TYPE_IMAGE = 3;
+  }
+  
+  message Image {
+    optional string alt_text = 1;
+    optional string caption = 2;
+    optional string credit = 3;
+    optional int32 height = 4;
+    string url_template = 6;
+    optional int32 width = 7;
+  }
+  
+  message Video {
+    optional string alt_text = 1;
+    optional string caption = 2;
+    optional string credit = 3;
+    optional int32 height = 4;
+    optional string orientation = 5;
+    string url = 6;
+    optional int32 width = 7;
+  }
+  
+  // This message is only applicable to live blogs.
+  message LiveEvent {
+    string id = 1;
+    string title = 2;
+    string body = 3;
+    optional google.protobuf.Timestamp published_date = 4;
+    optional google.protobuf.Timestamp last_updated_date = 5;
+  }
+
+message Branding {
+    string branding_type = 1;
+    string sponsor_name = 2;
+    string logo = 3;
+    string sponsor_uri = 4;
+    string label = 5;
+    string about_uri = 6;
+  }
+  
+  /**
+   * The rendering platform support object is required to support opening AR
+   * articles on native clients.We don't return this message if the corresponding
+   * article cannot be rendered by the server (instead only by legacy article
+   * templates).
+   */
+  message RenderingPlatformSupport {
+    string min_bridget_version = 1;
+    string uri = 2;
+  }
+  
+  message Article {
+    string id = 1;
+    optional string byline = 2;
+    repeated Image images = 3;
+    Links links = 4;
+    optional string kicker = 5;
+    string title = 6;
+    optional string trail_text = 7;
+    optional int32 rating = 8;
+    optional int32 comment_count = 9;
+    optional google.protobuf.Timestamp published_date = 10;
+    optional google.protobuf.Timestamp last_updated_date = 11;
+    optional MediaType media_type = 12;
+    // Only expected for video or audio content.
+    optional google.protobuf.Duration duration = 13;
+    // MAPI will never return both images and a profile_image.
+    optional Image profile_image = 14;
+    repeated LiveEvent events = 15;
+    optional Palette palette_light = 16;
+    optional Palette palette_dark = 17;
+    // Only applicable to podcasts.
+    optional string apple_podcast_url = 18;
+    // Only applicable to podcasts.
+    optional string google_podcast_url = 19;
+    // Only applicable to podcasts.
+    optional string spotify_podcast_url = 20;
+    repeated Video videos = 21;
+    /**
+     * This is an indicator as to whether a live blog is still blogging, or if
+     * it's been closed.
+     */
+    optional bool is_live = 22;
+    // Only applicable to podcasts.
+    optional string pocket_cast_podcast_url = 23;
+    optional RenderingPlatformSupport rendered_item_prod = 24;
+    optional RenderingPlatformSupport rendered_item_beta = 25;
+    // Quoted headline shown for a card if selected in the fronts tool.
+    optional bool show_quoted_headline = 26;
+  }
+  
+  message Card {
+    enum CardType {
+      CARD_TYPE_UNSPECIFIED = 0;
+      CARD_TYPE_ARTICLE = 1;
+      CARD_TYPE_PODCAST = 2;
+      CARD_TYPE_VIDEO = 3;
+      CARD_TYPE_CROSSWORD = 4;
+      /**
+       * Display cards have their own separate design (see figma designs for
+       * ref).
+       */
+      CARD_TYPE_DISPLAY = 5;
+      CARD_TYPE_MOSTVIEWED = 6;
+      /**
+      * An empty card is used to indicate an empty space so that the native
+      * client do not stretch the previous card to occupy the space
+      */  
+      CARD_TYPE_EMPTY = 7;
+    }
+    CardType type = 1;
+    Article article = 2;
+    /**
+     * Boosted cards show a boosted headline size and a main image that spans
+     * full width on mobile.
+     */
+    optional bool boosted = 3;
+    /**
+     * Compact cards don't show all the information that non-compact cards do,
+     * and tend to appear in a carousel.
+     */
+    optional bool compact = 4;
+    repeated Article sublinks = 5;
+    optional string html_fallback = 6;
+    /**
+     * Individual cards can be branded and not be part of a branded container.
+     * Cards that are branded tend to show the sponsor logo and should be
+     * returned with a different palette.
+     */
+    optional Branding branding = 7;
+    /**
+     * Individual cards can be defined as "premium content". If premium_content
+     * is true then it implies the card should be hidden from signed-in users,
+     * for example if the card has been paid for by an external sponsor.
+     */
+    optional bool premium_content = 8;
+    optional Palette sublinks_palette_light = 9;
+    optional Palette sublinks_palette_dark = 10;
+  }
+  
+  message Column {
+    /**
+     * By default, if there are multiple cards in the cards array then it's
+     * expected the client will display these as stacked vertical elements.
+     */
+    repeated Card cards = 1;
+    optional Palette palette_light = 2;
+    optional Palette palette_dark = 3;
+    // The card(s) in the column assume this preferred width.
+    int32 preferred_width = 4;
+  }
+
+  /**
+ * This is a special type of container on a front that is delivered via
+ * editorial tools.Thrashers are used to promote either features or
+ * commercial content.
+ */
+ message Thrasher {
+  string uri = 1;
+}
+
+  
+  message Row {
+    enum RowType {
+      ROW_TYPE_UNSPECIFIED = 0;
+      // Layout is the "default" way of laying out rows and columns.
+      ROW_TYPE_LAYOUT = 1;
+      ROW_TYPE_CAROUSEL = 2;
+      ROW_TYPE_THRASHER = 3;
+    }
+    repeated Column columns = 1;
+    optional Palette palette_light = 2;
+    optional Palette palette_dark = 3;
+    /**
+     * Tablet devices support a 4 column display, whereas mobile devices
+     * support a 2 column display. If a mobile device receives a row with a
+     * preferred number of columns greater than 2, the additional columns are
+     * "wrapped" onto an extra row (a bit like CSS flex-wrap).
+     */
+    int32 preferred_number_of_columns = 4;
+    optional Thrasher thrasher = 5;
+    RowType type = 6;
+    optional string title = 7;
+  }

--- a/proto/shared.proto
+++ b/proto/shared.proto
@@ -6,215 +6,215 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 message Palette {
-    string accent_colour = 1;
-    string background = 2;
-    string comment_count = 3;
-    string element_background = 4;
-    string headline = 5;
-    string immersive_kicker = 6;
-    string main = 7;
-    string media_background = 8;
-    string media_icon = 9;
-    string meta_text = 10;
-    string pill = 11;
-    string pillar = 12;
-    string secondary = 13;
-    string shadow = 14;
-    string top_border = 15;
-  }
+  string accent_colour = 1;
+  string background = 2;
+  string comment_count = 3;
+  string element_background = 4;
+  string headline = 5;
+  string immersive_kicker = 6;
+  string main = 7;
+  string media_background = 8;
+  string media_icon = 9;
+  string meta_text = 10;
+  string pill = 11;
+  string pillar = 12;
+  string secondary = 13;
+  string shadow = 14;
+  string top_border = 15;
+}
   
-  message Links {
-    string related_uri = 1;
-    string short_url = 2;
-    string uri = 3;
-    string web_uri = 4;
-  }
+message Links {
+  string related_uri = 1;
+  string short_url = 2;
+  string uri = 3;
+  string web_uri = 4;
+}
   
-  enum MediaType {
-    MEDIA_TYPE_UNSPECIFIED = 0;
-    MEDIA_TYPE_VIDEO = 1;
-    MEDIA_TYPE_AUDIO = 2;
-    MEDIA_TYPE_IMAGE = 3;
-  }
+enum MediaType {
+  MEDIA_TYPE_UNSPECIFIED = 0;
+  MEDIA_TYPE_VIDEO = 1;
+  MEDIA_TYPE_AUDIO = 2;
+  MEDIA_TYPE_IMAGE = 3;
+}
   
-  message Image {
-    optional string alt_text = 1;
-    optional string caption = 2;
-    optional string credit = 3;
-    optional int32 height = 4;
-    string url_template = 6;
-    optional int32 width = 7;
-  }
+message Image {
+  optional string alt_text = 1;
+  optional string caption = 2;
+  optional string credit = 3;
+  optional int32 height = 4;
+  string url_template = 6;
+  optional int32 width = 7;
+}
   
-  message Video {
-    optional string alt_text = 1;
-    optional string caption = 2;
-    optional string credit = 3;
-    optional int32 height = 4;
-    optional string orientation = 5;
-    string url = 6;
-    optional int32 width = 7;
-  }
+message Video {
+  optional string alt_text = 1;
+  optional string caption = 2;
+  optional string credit = 3;
+  optional int32 height = 4;
+  optional string orientation = 5;
+  string url = 6;
+  optional int32 width = 7;
+}
   
-  // This message is only applicable to live blogs.
-  message LiveEvent {
-    string id = 1;
-    string title = 2;
-    string body = 3;
-    optional google.protobuf.Timestamp published_date = 4;
-    optional google.protobuf.Timestamp last_updated_date = 5;
-  }
+// This message is only applicable to live blogs.
+message LiveEvent {
+  string id = 1;
+  string title = 2;
+  string body = 3;
+  optional google.protobuf.Timestamp published_date = 4;
+  optional google.protobuf.Timestamp last_updated_date = 5;
+}
 
 message Branding {
-    string branding_type = 1;
-    string sponsor_name = 2;
-    string logo = 3;
-    string sponsor_uri = 4;
-    string label = 5;
-    string about_uri = 6;
-  }
+  string branding_type = 1;
+  string sponsor_name = 2;
+  string logo = 3;
+  string sponsor_uri = 4;
+  string label = 5;
+  string about_uri = 6;
+}
   
-  /**
+/**
    * The rendering platform support object is required to support opening AR
    * articles on native clients.We don't return this message if the corresponding
    * article cannot be rendered by the server (instead only by legacy article
    * templates).
    */
-  message RenderingPlatformSupport {
-    string min_bridget_version = 1;
-    string uri = 2;
-  }
+message RenderingPlatformSupport {
+  string min_bridget_version = 1;
+  string uri = 2;
+}
   
-  message Article {
-    string id = 1;
-    optional string byline = 2;
-    repeated Image images = 3;
-    Links links = 4;
-    optional string kicker = 5;
-    string title = 6;
-    optional string trail_text = 7;
-    optional int32 rating = 8;
-    optional int32 comment_count = 9;
-    optional google.protobuf.Timestamp published_date = 10;
-    optional google.protobuf.Timestamp last_updated_date = 11;
-    optional MediaType media_type = 12;
-    // Only expected for video or audio content.
-    optional google.protobuf.Duration duration = 13;
-    // MAPI will never return both images and a profile_image.
-    optional Image profile_image = 14;
-    repeated LiveEvent events = 15;
-    optional Palette palette_light = 16;
-    optional Palette palette_dark = 17;
-    // Only applicable to podcasts.
-    optional string apple_podcast_url = 18;
-    // Only applicable to podcasts.
-    optional string google_podcast_url = 19;
-    // Only applicable to podcasts.
-    optional string spotify_podcast_url = 20;
-    repeated Video videos = 21;
-    /**
+message Article {
+  string id = 1;
+  optional string byline = 2;
+  repeated Image images = 3;
+  Links links = 4;
+  optional string kicker = 5;
+  string title = 6;
+  optional string trail_text = 7;
+  optional int32 rating = 8;
+  optional int32 comment_count = 9;
+  optional google.protobuf.Timestamp published_date = 10;
+  optional google.protobuf.Timestamp last_updated_date = 11;
+  optional MediaType media_type = 12;
+  // Only expected for video or audio content.
+  optional google.protobuf.Duration duration = 13;
+  // MAPI will never return both images and a profile_image.
+  optional Image profile_image = 14;
+  repeated LiveEvent events = 15;
+  optional Palette palette_light = 16;
+  optional Palette palette_dark = 17;
+  // Only applicable to podcasts.
+  optional string apple_podcast_url = 18;
+  // Only applicable to podcasts.
+  optional string google_podcast_url = 19;
+  // Only applicable to podcasts.
+  optional string spotify_podcast_url = 20;
+  repeated Video videos = 21;
+  /**
      * This is an indicator as to whether a live blog is still blogging, or if
      * it's been closed.
      */
-    optional bool is_live = 22;
-    // Only applicable to podcasts.
-    optional string pocket_cast_podcast_url = 23;
-    optional RenderingPlatformSupport rendered_item_prod = 24;
-    optional RenderingPlatformSupport rendered_item_beta = 25;
-    // Quoted headline shown for a card if selected in the fronts tool.
-    optional bool show_quoted_headline = 26;
-  }
+  optional bool is_live = 22;
+  // Only applicable to podcasts.
+  optional string pocket_cast_podcast_url = 23;
+  optional RenderingPlatformSupport rendered_item_prod = 24;
+  optional RenderingPlatformSupport rendered_item_beta = 25;
+  // Quoted headline shown for a card if selected in the fronts tool.
+  optional bool show_quoted_headline = 26;
+}
   
-  message Card {
-    enum CardType {
-      CARD_TYPE_UNSPECIFIED = 0;
-      CARD_TYPE_ARTICLE = 1;
-      CARD_TYPE_PODCAST = 2;
-      CARD_TYPE_VIDEO = 3;
-      CARD_TYPE_CROSSWORD = 4;
-      /**
+message Card {
+  enum CardType {
+    CARD_TYPE_UNSPECIFIED = 0;
+    CARD_TYPE_ARTICLE = 1;
+    CARD_TYPE_PODCAST = 2;
+    CARD_TYPE_VIDEO = 3;
+    CARD_TYPE_CROSSWORD = 4;
+    /**
        * Display cards have their own separate design (see figma designs for
        * ref).
        */
-      CARD_TYPE_DISPLAY = 5;
-      CARD_TYPE_MOSTVIEWED = 6;
-      /**
+    CARD_TYPE_DISPLAY = 5;
+    CARD_TYPE_MOSTVIEWED = 6;
+    /**
       * An empty card is used to indicate an empty space so that the native
       * client do not stretch the previous card to occupy the space
       */  
-      CARD_TYPE_EMPTY = 7;
-    }
-    CardType type = 1;
-    Article article = 2;
-    /**
+    CARD_TYPE_EMPTY = 7;
+  }
+  CardType type = 1;
+  Article article = 2;
+  /**
      * Boosted cards show a boosted headline size and a main image that spans
      * full width on mobile.
      */
-    optional bool boosted = 3;
-    /**
+  optional bool boosted = 3;
+  /**
      * Compact cards don't show all the information that non-compact cards do,
      * and tend to appear in a carousel.
      */
-    optional bool compact = 4;
-    repeated Article sublinks = 5;
-    optional string html_fallback = 6;
-    /**
+  optional bool compact = 4;
+  repeated Article sublinks = 5;
+  optional string html_fallback = 6;
+  /**
      * Individual cards can be branded and not be part of a branded container.
      * Cards that are branded tend to show the sponsor logo and should be
      * returned with a different palette.
      */
-    optional Branding branding = 7;
-    /**
+  optional Branding branding = 7;
+  /**
      * Individual cards can be defined as "premium content". If premium_content
      * is true then it implies the card should be hidden from signed-in users,
      * for example if the card has been paid for by an external sponsor.
      */
-    optional bool premium_content = 8;
-    optional Palette sublinks_palette_light = 9;
-    optional Palette sublinks_palette_dark = 10;
-  }
+  optional bool premium_content = 8;
+  optional Palette sublinks_palette_light = 9;
+  optional Palette sublinks_palette_dark = 10;
+}
   
-  message Column {
-    /**
+message Column {
+  /**
      * By default, if there are multiple cards in the cards array then it's
      * expected the client will display these as stacked vertical elements.
      */
-    repeated Card cards = 1;
-    optional Palette palette_light = 2;
-    optional Palette palette_dark = 3;
-    // The card(s) in the column assume this preferred width.
-    int32 preferred_width = 4;
-  }
+  repeated Card cards = 1;
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  // The card(s) in the column assume this preferred width.
+  int32 preferred_width = 4;
+}
 
-  /**
+/**
  * This is a special type of container on a front that is delivered via
  * editorial tools.Thrashers are used to promote either features or
  * commercial content.
  */
- message Thrasher {
+message Thrasher {
   string uri = 1;
 }
 
   
-  message Row {
-    enum RowType {
-      ROW_TYPE_UNSPECIFIED = 0;
-      // Layout is the "default" way of laying out rows and columns.
-      ROW_TYPE_LAYOUT = 1;
-      ROW_TYPE_CAROUSEL = 2;
-      ROW_TYPE_THRASHER = 3;
-    }
-    repeated Column columns = 1;
-    optional Palette palette_light = 2;
-    optional Palette palette_dark = 3;
-    /**
+message Row {
+  enum RowType {
+    ROW_TYPE_UNSPECIFIED = 0;
+    // Layout is the "default" way of laying out rows and columns.
+    ROW_TYPE_LAYOUT = 1;
+    ROW_TYPE_CAROUSEL = 2;
+    ROW_TYPE_THRASHER = 3;
+  }
+  repeated Column columns = 1;
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  /**
      * Tablet devices support a 4 column display, whereas mobile devices
      * support a 2 column display. If a mobile device receives a row with a
      * preferred number of columns greater than 2, the additional columns are
      * "wrapped" onto an extra row (a bit like CSS flex-wrap).
      */
-    int32 preferred_number_of_columns = 4;
-    optional Thrasher thrasher = 5;
-    RowType type = 6;
-    optional string title = 7;
-  }
+  int32 preferred_number_of_columns = 4;
+  optional Thrasher thrasher = 5;
+  RowType type = 6;
+  optional string title = 7;
+}

--- a/proto/shared.proto
+++ b/proto/shared.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package com.gu.mobile.mapi.models.v0;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
-
 message Palette {
   string accent_colour = 1;
   string background = 2;

--- a/proto/shared.proto
+++ b/proto/shared.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package com.gu.mobile.mapi.models.v0;
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
 message Palette {
   string accent_colour = 1;
   string background = 2;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 This PR adds two new proto files so that we now have

- collection.proto (for definitions only needed by collection response)
- list.proto (for definitions only needed by list response)
- shared.proto (for definitions shared between the others)
 
 This perhaps makes more sense semantically rather than just constantly adding to collection.proto, and also makes the code base a bit easier to understand/maintain, but it will introduce breaking changes. 

## Screenshot from MAPI

<img width="700" alt="Screenshot 2023-08-01 at 11 58 23" src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/1e9e26a5-13df-4226-90ed-6efd3b0870c0">

## How to test

I've released a snapshot, imported that into MAPI, changed all the MAPI imports, and then tried testing on the iOS simulator - it doesn't work on the iOS simulator, I'm assuming because of these breaking changes. 

## Further discussion needed

The alternative would be to keep adding to the collection.proto file, but this may not make for as scalable/maintanable code as we choose to expand. For example, what if we want to return an entire blueprint front response in the future? Where would this live in our current singular collection.proto file structure?