### PR TITLE
Add numbered cards to blueprint.proto

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -243,7 +243,7 @@ message Card {
      * ref).
      */
     CARD_TYPE_DISPLAY = 5;
-    CARD_TYPE_MOSTVIEWED = 6;
+    CARD_TYPE_NUMBERED = 6;
     /**
     * An empty card is used to indicate an empty space so that the native
     * client do not stretch the previous card to occupy the space
@@ -278,6 +278,10 @@ message Card {
   optional bool premium_content = 8;
   optional Palette sublinks_palette_light = 9;
   optional Palette sublinks_palette_dark = 10;
+  /**
+   * This is the number to be used when the card type is CARD_TYPE_NUMBERED.
+   */
+  optional int32 card_number = 11;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -71,7 +71,7 @@
                 "integer": 5
               },
               {
-                "name": "CARD_TYPE_MOSTVIEWED",
+                "name": "CARD_TYPE_NUMBERED",
                 "integer": 6
               },
               {
@@ -715,6 +715,12 @@
                 "id": 10,
                 "name": "sublinks_palette_dark",
                 "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "card_number",
+                "type": "int32",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new property for numbered cards.
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
