### PR TITLE
Support snap links

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -195,9 +195,9 @@ message Article {
   string id = 1;
   optional string byline = 2;
   repeated Image images = 3;
-  Links links = 4;
+  optional Links links = 4;
   optional string kicker = 5;
-  string title = 6;
+  optional string title = 6;
   optional string trail_text = 7;
   optional int32 rating = 8;
   optional int32 comment_count = 9;
@@ -229,6 +229,8 @@ message Article {
   optional RenderingPlatformSupport rendered_item_beta = 25;
   // Quoted headline shown for a card if selected in the fronts tool.
   optional bool show_quoted_headline = 26;
+  // Only applicable to link snap (thrasher) cards
+  optional string thrasher_uri = 27;
 }
 
 message Card {
@@ -249,6 +251,12 @@ message Card {
     * client do not stretch the previous card to occupy the space
     */  
     CARD_TYPE_EMPTY = 7;
+    /**
+     * Used when a card has a "link snap", which is an atom for a front
+     * (= a thrasher) and is placed inside a regular container alongside
+     * other cards.
+     */
+    CARD_TYPE_THRASHER = 8;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -229,8 +229,8 @@ message Article {
   optional RenderingPlatformSupport rendered_item_beta = 25;
   // Quoted headline shown for a card if selected in the fronts tool.
   optional bool show_quoted_headline = 26;
-  // Only applicable to link snap (thrasher) cards
-  optional string thrasher_uri = 27;
+  // Only applicable to cards that display web content (e.g. snap links)
+  optional string web_content_uri = 27;
 }
 
 message Card {
@@ -252,11 +252,11 @@ message Card {
     */  
     CARD_TYPE_EMPTY = 7;
     /**
-     * Used when a card has a "link snap", which is an atom for a front
-     * (= a thrasher) and is placed inside a regular container alongside
-     * other cards.
+     * Used when a card should display content using a web view. Initially
+     * this has been implemented for "snap links", which are atoms for a
+     * front placed inside a regular container alongside other cards.
      */
-    CARD_TYPE_THRASHER = 8;
+    CARD_TYPE_WEB_CONTENT = 8;
   }
   CardType type = 1;
   Article article = 2;
@@ -310,7 +310,11 @@ message Row {
     // Layout is the "default" way of laying out rows and columns.
     ROW_TYPE_LAYOUT = 1;
     ROW_TYPE_CAROUSEL = 2;
-    ROW_TYPE_THRASHER = 3;
+    /**
+     * Used when the entire row only contains web content, for example
+     * when thrashers are displayed inside a fixed/thrasher container.
+     */
+    ROW_TYPE_WEB_CONTENT = 3;
   }
   repeated Column columns = 1;
   optional Palette palette_light = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -77,6 +77,10 @@
               {
                 "name": "CARD_TYPE_EMPTY",
                 "integer": 7
+              },
+              {
+                "name": "CARD_TYPE_THRASHER",
+                "integer": 8
               }
             ]
           },
@@ -521,7 +525,8 @@
               {
                 "id": 4,
                 "name": "links",
-                "type": "Links"
+                "type": "Links",
+                "optional": true
               },
               {
                 "id": 5,
@@ -532,7 +537,8 @@
               {
                 "id": 6,
                 "name": "title",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 7,
@@ -652,6 +658,12 @@
                 "id": 26,
                 "name": "show_quoted_headline",
                 "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 27,
+                "name": "thrasher_uri",
+                "type": "string",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -79,7 +79,7 @@
                 "integer": 7
               },
               {
-                "name": "CARD_TYPE_THRASHER",
+                "name": "CARD_TYPE_WEB_CONTENT",
                 "integer": 8
               }
             ]
@@ -99,7 +99,7 @@
                 "integer": 2
               },
               {
-                "name": "ROW_TYPE_THRASHER",
+                "name": "ROW_TYPE_WEB_CONTENT",
                 "integer": 3
               }
             ]
@@ -662,7 +662,7 @@
               },
               {
                 "id": 27,
-                "name": "thrasher_uri",
+                "name": "web_content_uri",
                 "type": "string",
                 "optional": true
               }


### PR DESCRIPTION
## What does this change?

This adds support for snap links. Snap links are thrashers (atoms) that can be added to any container on a front, the thrashers will appear alongside typical article cards.

For example, in the tooling we can add link snaps to a container:
<img width="600px" alt="Screenshot 2023-09-13 at 12 30 43" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/5be01808-d6a7-4688-9c26-94716cb16123">

Which, on web (for now), results in the thrasher appearing in the container:
<img width="600px" alt="Screenshot 2023-09-13 at 12 33 46" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/ed6649f3-a93d-4bad-91fd-6ca0803e5bc0">

To support this change we make a couple of non-breaking schema changes:
- we add a new card type for the thrasher
- we add a new optional property (`thrasher_uri`) inside the Article
- we make all Article properties optional, because thrashers do not have a title or Links.

## How to test

A [snapshot](https://github.com/guardian/mobile-apps-api-models/releases/tag/v0.0.21.1-SNAPSHOT) was released and we have a working [draft](https://github.com/guardian/mobile-apps-api/pull/2698) of a MAPI implementation. The draft MAPI implementation returns snap links according to the new schema definition, e.g.
<img width="600px" alt="Screenshot 2023-09-13 at 12 37 01" src="https://github.com/guardian/mobile-apps-api-models/assets/45561419/0199ed9a-9b08-4162-9949-86a3561ac26a">


