### PR TITLE
Add topics to lists

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -332,5 +332,5 @@ message Row {
 
 message Topic {
   string type = 1;
-  string name = 1;
+  string name = 2;
 }

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -101,8 +101,8 @@ message List {
   optional Palette palette_dark = 4;
   repeated Row rows = 5;
   optional Branding branding = 6;
+  repeated Topic topics = 7;
 }
-
 
 /************************* SHARED *************************/
 
@@ -169,7 +169,6 @@ message LiveEvent {
   optional google.protobuf.Timestamp published_date = 4;
   optional google.protobuf.Timestamp last_updated_date = 5;
 }
-
 
 message Branding {
   string branding_type = 1;
@@ -329,4 +328,9 @@ message Row {
   optional Thrasher thrasher = 5;
   RowType type = 6;
   optional string title = 7;
+}
+
+message Topic {
+  string type = 1;
+  string name = 1;
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -226,6 +226,12 @@
                 "name": "branding",
                 "type": "Branding",
                 "optional": true
+              },
+              {
+                "id": 7,
+                "name": "topics",
+                "type": "Topic",
+                "is_repeated": true
               }
             ]
           },
@@ -809,7 +815,22 @@
                 "optional": true
               }
             ]
-          }
+          },
+          {
+            "name": "Topic",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              }
+            ]
+          },
         ],
         "imports": [
           {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -830,7 +830,7 @@
                 "type": "string"
               }
             ]
-          },
+          }
         ],
         "imports": [
           {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds topics to our blueprint list. The app uses the information to allow users to subscribe to notifications for that topic. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="411" alt="Screenshot 2023-09-21 at 14 31 13" src="https://github.com/guardian/mobile-apps-api-models/assets/104841688/b94b0851-9d9f-40d6-a236-c24a43b45af9">
<img width="433" alt="Screenshot 2023-09-21 at 14 27 29" src="https://github.com/guardian/mobile-apps-api-models/assets/104841688/08ba4c7b-4e62-4c97-86a2-ea3360c9994b">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
