### PR TITLE
Add alt_logo to branding

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -177,6 +177,7 @@ message Branding {
   string sponsor_uri = 4;
   string label = 5;
   string about_uri = 6;
+  optional string alt_logo = 7;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -490,6 +490,12 @@
                 "id": 6,
                 "name": "about_uri",
                 "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "alt_logo",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
## What does this change?

This pr adds an optional `alt_logo` field to our branding object. Making it optional seems to be consistent with the Branding data type we get from the commercial package as can be seen in the screenshot below.

<img width="388" alt="image" src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/9c0b4352-1057-4d91-998f-cc818844b944">

This is a prerequisite step to [this ticket](https://theguardian.atlassian.net/browse/LIVE-5768)

