### PR TITLE
Add tracking fields for lists

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -104,6 +104,24 @@ message List {
   repeated Topic topics = 7;
   optional string ad_targeting_path = 8;
   optional string previous_page_url = 9;
+
+  /**
+   * These fields are for tracking.
+   */
+  Permutive permutive = 10;
+  optional string nielsen = 11;
+
+}
+
+message Permutive {
+  string id = 1;
+  string type = 2;
+  optional string title = 3;
+  optional string section = 4;
+  repeated string authors = 5;
+  repeated string keywords = 6;
+  optional google.protobuf.Timestamp published_at = 7;
+  optional string series = 8;
 }
 
 /************************* SHARED *************************/

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -107,24 +107,6 @@ message List {
   Tracking tracking = 10;
 }
 
-/** Fields related to tracking on lists */
-
-message Tracking {
-  Permutive permutive = 1;
-  optional string nielsen_section = 2;
-}
-
-message Permutive {
-  string id = 1;
-  string type = 2;
-  optional string title = 3;
-  optional string section = 4;
-  repeated string authors = 5;
-  repeated string keywords = 6;
-  optional google.protobuf.Timestamp published_at = 7;
-  optional string series = 8;
-}
-
 /************************* SHARED *************************/
 
 
@@ -355,4 +337,22 @@ message Row {
 message Topic {
   string type = 1;
   string name = 2;
+}
+
+/** Tracking messages */
+
+message Tracking {
+  Permutive permutive = 1;
+  optional string nielsen_section = 2;
+}
+
+message Permutive {
+  string id = 1;
+  string type = 2;
+  optional string title = 3;
+  optional string section = 4;
+  repeated string authors = 5;
+  repeated string keywords = 6;
+  optional google.protobuf.Timestamp published_at = 7;
+  optional string series = 8;
 }

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -104,13 +104,14 @@ message List {
   repeated Topic topics = 7;
   optional string ad_targeting_path = 8;
   optional string previous_page_url = 9;
+  Tracking tracking = 10;
+}
 
-  /**
-   * These fields are for tracking.
-   */
-  Permutive permutive = 10;
-  optional string nielsen = 11;
+/** Fields related to tracking on lists */
 
+message Tracking {
+  Permutive permutive = 1;
+  optional string nielsen_section = 2;
 }
 
 message Permutive {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -247,12 +247,22 @@
               },
               {
                 "id": 10,
+                "name": "tracking",
+                "type": "Tracking"
+              }
+            ]
+          },
+          {
+            "name": "Tracking",
+            "fields": [
+              {
+                "id": 1,
                 "name": "permutive",
                 "type": "Permutive"
               },
               {
-                "id": 11,
-                "name": "nielsen",
+                "id": 2,
+                "name": "nielsen_section",
                 "type": "string",
                 "optional": true
               }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -244,6 +244,68 @@
                 "name": "previous_page_url",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 10,
+                "name": "permutive",
+                "type": "Permutive"
+              },
+              {
+                "id": 11,
+                "name": "nielsen",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "Permutive",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "section",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "authors",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "keywords",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "published_at",
+                "type": "google.protobuf.Timestamp",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "series",
+                "type": "string",
+                "optional": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -253,73 +253,6 @@
             ]
           },
           {
-            "name": "Tracking",
-            "fields": [
-              {
-                "id": 1,
-                "name": "permutive",
-                "type": "Permutive"
-              },
-              {
-                "id": 2,
-                "name": "nielsen_section",
-                "type": "string",
-                "optional": true
-              }
-            ]
-          },
-          {
-            "name": "Permutive",
-            "fields": [
-              {
-                "id": 1,
-                "name": "id",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "type",
-                "type": "string"
-              },
-              {
-                "id": 3,
-                "name": "title",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 4,
-                "name": "section",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 5,
-                "name": "authors",
-                "type": "string",
-                "is_repeated": true
-              },
-              {
-                "id": 6,
-                "name": "keywords",
-                "type": "string",
-                "is_repeated": true
-              },
-              {
-                "id": 7,
-                "name": "published_at",
-                "type": "google.protobuf.Timestamp",
-                "optional": true
-              },
-              {
-                "id": 8,
-                "name": "series",
-                "type": "string",
-                "optional": true
-              }
-            ]
-          },
-          {
             "name": "Palette",
             "fields": [
               {
@@ -918,6 +851,73 @@
                 "id": 2,
                 "name": "name",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Tracking",
+            "fields": [
+              {
+                "id": 1,
+                "name": "permutive",
+                "type": "Permutive"
+              },
+              {
+                "id": 2,
+                "name": "nielsen_section",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "Permutive",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "section",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "authors",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "keywords",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "published_at",
+                "type": "google.protobuf.Timestamp",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "series",
+                "type": "string",
+                "optional": true
               }
             ]
           }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 This PR adds tracking fields to the lists response  - `Permutive` and `nielsen`.

## Do we need any more tracking?

Native devs - I've tried to ascertain what tracking we need for lists based on [this iOS pr that implemented tracking for fronts](https://github.com/guardian/ios-live/pull/7303).

According to the iOS PR, the tracking migrated was Ophan, Nielsen, Sourcepoint and Permutive. As far as I can see, MAPI doesn’t pass any tracking information for Ophan or Sourcepoint, which means we probably just need to include Nielsen and Permutive data. This is backed up by the fact that the prod fronts response only included info about Nielsen and Permutive. 

With that being said, [this code](https://github.com/guardian/ios-live/pull/7303/files#diff-f994ef1a55d0fad2b56961f192d2a5005bda14f7ebf5d51e0afbf573d555173aR164-R173) may suggest there are other fields we need to pass such as `targetingParameters` and `keywords`, though I am unsure what these would be from a MAPI perspective. Can native devs confirm if they're expecting these from MAPI?

## Screenshots

Below is a screenshot of a lists response that shows the fields we're migrating over. Note before that `nielsenSection` was in a`tracking` object whilst `permutiveTracking` was separate. We've now merged these into one tracking object. 

## Screenshots

| Old lists response | Blueprint response |
| --- | --- |
| <img src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/f0d1279c-1e76-486b-976e-09021ec660d9" width="300px" /> | <img src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/01150b8d-fce3-4400-98d4-f63f83ef3cb4" width="300px" /> |

