### PR TITLE
Add tracking fields for articles

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -114,17 +114,6 @@ message Tracking {
   optional string nielsen_section = 2;
 }
 
-message Permutive {
-  string id = 1;
-  string type = 2;
-  optional string title = 3;
-  optional string section = 4;
-  repeated string authors = 5;
-  repeated string keywords = 6;
-  optional google.protobuf.Timestamp published_at = 7;
-  optional string series = 8;
-}
-
 /************************* SHARED *************************/
 
 
@@ -252,6 +241,10 @@ message Article {
   optional bool show_quoted_headline = 26;
   // Only applicable to cards that display web content (e.g. snap links)
   optional string web_content_uri = 27;
+  Permutive permutive = 28;
+  optional string nielsen = 29;
+  repeated BasicTag commissiong_desks = 30;
+  
 }
 
 message Card {
@@ -355,4 +348,22 @@ message Row {
 message Topic {
   string type = 1;
   string name = 2;
+}
+
+/** Tracking messages */
+message Permutive {
+  string id = 1;
+  string type = 2;
+  optional string title = 3;
+  optional string section = 4;
+  repeated string authors = 5;
+  repeated string keywords = 6;
+  optional google.protobuf.Timestamp published_at = 7;
+  optional string series = 8;
+}
+
+/** Only used for Article message */
+message BasicTag { 
+  string id = 1;
+  string webTitle = 2;
 }

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -107,12 +107,6 @@ message List {
   Tracking tracking = 10;
 }
 
-/** Fields related to tracking on lists */
-
-message Tracking {
-  Permutive permutive = 1;
-  optional string nielsen_section = 2;
-}
 
 /************************* SHARED *************************/
 
@@ -241,9 +235,7 @@ message Article {
   optional bool show_quoted_headline = 26;
   // Only applicable to cards that display web content (e.g. snap links)
   optional string web_content_uri = 27;
-  Permutive permutive = 28;
-  optional string nielsen = 29;
-  repeated BasicTag commissiong_desks = 30;
+  Tracking tracking = 28;
   
 }
 
@@ -351,6 +343,13 @@ message Topic {
 }
 
 /** Tracking messages */
+
+message Tracking {
+  Permutive permutive = 1;
+  optional string nielsen_section = 2;
+  repeated BasicTag commissioning_desks = 3;
+}
+
 message Permutive {
   string id = 1;
   string type = 2;
@@ -362,7 +361,7 @@ message Permutive {
   optional string series = 8;
 }
 
-/** Tracking, only used for Article message */
+/** This tracking field is only used for Article message */
 message BasicTag { 
   string id = 1;
   string web_title = 2;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -362,8 +362,8 @@ message Permutive {
   optional string series = 8;
 }
 
-/** Only used for Article message */
+/** Tracking, only used for Article message */
 message BasicTag { 
   string id = 1;
-  string webTitle = 2;
+  string web_title = 2;
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -269,57 +269,6 @@
             ]
           },
           {
-            "name": "Permutive",
-            "fields": [
-              {
-                "id": 1,
-                "name": "id",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "type",
-                "type": "string"
-              },
-              {
-                "id": 3,
-                "name": "title",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 4,
-                "name": "section",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 5,
-                "name": "authors",
-                "type": "string",
-                "is_repeated": true
-              },
-              {
-                "id": 6,
-                "name": "keywords",
-                "type": "string",
-                "is_repeated": true
-              },
-              {
-                "id": 7,
-                "name": "published_at",
-                "type": "google.protobuf.Timestamp",
-                "optional": true
-              },
-              {
-                "id": 8,
-                "name": "series",
-                "type": "string",
-                "optional": true
-              }
-            ]
-          },
-          {
             "name": "Palette",
             "fields": [
               {
@@ -761,6 +710,23 @@
                 "name": "web_content_uri",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 28,
+                "name": "permutive",
+                "type": "Permutive"
+              },
+              {
+                "id": 29,
+                "name": "nielsen",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 30,
+                "name": "commissiong_desks",
+                "type": "BasicTag",
+                "is_repeated": true
               }
             ]
           },
@@ -917,6 +883,72 @@
               {
                 "id": 2,
                 "name": "name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Permutive",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "section",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "authors",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "keywords",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "published_at",
+                "type": "google.protobuf.Timestamp",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "series",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "BasicTag",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "webTitle",
                 "type": "string"
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -948,7 +948,7 @@
               },
               {
                 "id": 2,
-                "name": "webTitle",
+                "name": "web_title",
                 "type": "string"
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -253,22 +253,6 @@
             ]
           },
           {
-            "name": "Tracking",
-            "fields": [
-              {
-                "id": 1,
-                "name": "permutive",
-                "type": "Permutive"
-              },
-              {
-                "id": 2,
-                "name": "nielsen_section",
-                "type": "string",
-                "optional": true
-              }
-            ]
-          },
-          {
             "name": "Palette",
             "fields": [
               {
@@ -713,20 +697,8 @@
               },
               {
                 "id": 28,
-                "name": "permutive",
-                "type": "Permutive"
-              },
-              {
-                "id": 29,
-                "name": "nielsen",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 30,
-                "name": "commissiong_desks",
-                "type": "BasicTag",
-                "is_repeated": true
+                "name": "tracking",
+                "type": "Tracking"
               }
             ]
           },
@@ -884,6 +856,28 @@
                 "id": 2,
                 "name": "name",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Tracking",
+            "fields": [
+              {
+                "id": 1,
+                "name": "permutive",
+                "type": "Permutive"
+              },
+              {
+                "id": 2,
+                "name": "nielsen_section",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "commissioning_desks",
+                "type": "BasicTag",
+                "is_repeated": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds tracking for articles (aka items - specifically rendered items that are served by AR/DCAR). This PR should enable the app to track without having to make a subsequent call to MAPI item. 

 I've added `permutive`, `nielsen` and `commissioning_desk` tracking types. 

## Do we need more tracking?

 I am assuming I've included everything necessary and haven't missed anything out, but it would be useful if native devs could confirm this.

## Screenshots

These screenshots show some of tracking fields I've migrated over from the item response. Note that there were essentially two tracking objects - `permutiveTracking` and `trackingVariables`. I've now merged these into one. 

| Old article response | Blueprint response |
| --- | --- |
| <img width="300" alt="Screenshot 2023-11-01 at 12 32 16" src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/0f607e0e-6322-4ddf-bbdf-81f3f0e55f0b"><img width="300" alt="Screenshot 2023-11-01 at 12 32 25" src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/b9c453ff-28ac-4dec-aeab-b080bd11fdda"> | <img src="https://github.com/guardian/mobile-apps-api-models/assets/102960825/549e9059-6fc2-47cf-831c-462183adba8c" width="300px" /> |
