### PR TITLE
LIVE-5979 Add audio fields to podcast card to support mini-player

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -165,6 +165,21 @@ message Video {
   optional int32 width = 7;
 }
 
+message Audio {
+  string id = 1;
+  optional string source = 2;
+  optional in32 duration_in_seconds = 3;
+  string url = 4;
+  string ad_free_url = 5;
+  optional string mime_type = 6;
+}
+
+message PodcastSeries {
+  string id = 1;
+  string title = 2;
+  string url = 3;
+}
+
 // This message is only applicable to live blogs.
 message LiveEvent {
   string id = 1;
@@ -236,7 +251,10 @@ message Article {
   // Only applicable to cards that display web content (e.g. snap links)
   optional string web_content_uri = 27;
   Tracking tracking = 28;
-  
+  // Only applicable to podcast card
+  optional Audio audio = 29;
+  // Only applicable to podcast card
+  optional PodcastSeries podcast_series = 30;
 }
 
 message Card {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -168,7 +168,7 @@ message Video {
 message Audio {
   string id = 1;
   optional string source = 2;
-  optional in32 duration_in_seconds = 3;
+  optional int32 duration_in_seconds = 3;
   string url = 4;
   string ad_free_url = 5;
   optional string mime_type = 6;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -169,8 +169,8 @@ message Audio {
   string id = 1;
   optional string source = 2;
   optional int32 duration_in_seconds = 3;
-  string url = 4;
-  string ad_free_url = 5;
+  string uri = 4;
+  string ad_free_uri = 5;
   optional string mime_type = 6;
 }
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -450,6 +450,64 @@
             ]
           },
           {
+            "name": "Audio",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "source",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "duration_in_seconds",
+                "type": "in32",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "url",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "ad_free_url",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "mime_type",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "PodcastSeries",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "title",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "url",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "LiveEvent",
             "fields": [
               {
@@ -705,6 +763,18 @@
                 "id": 28,
                 "name": "tracking",
                 "type": "Tracking"
+              },
+              {
+                "id": 29,
+                "name": "audio",
+                "type": "Audio",
+                "optional": true
+              },
+              {
+                "id": 30,
+                "name": "podcast_series",
+                "type": "PodcastSeries",
+                "optional": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -471,12 +471,12 @@
               },
               {
                 "id": 4,
-                "name": "url",
+                "name": "uri",
                 "type": "string"
               },
               {
                 "id": 5,
-                "name": "ad_free_url",
+                "name": "ad_free_uri",
                 "type": "string"
               },
               {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -466,7 +466,7 @@
               {
                 "id": 3,
                 "name": "duration_in_seconds",
-                "type": "in32",
+                "type": "int32",
                 "optional": true
               },
               {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The native devs have been developing the mini player which allows readers to play a podcast on the front.  This PR adds the data fields to `Article` message of the blueprint collection response which are required for the audio playback and the UI of the miniplayer.