### PR TITLE
Add `hideable` flag

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -45,6 +45,12 @@ message Collection {
    */
   optional bool premium_content = 7;
   optional FollowUp follow_up = 8;
+
+  /**
+    * This tells the app whether or not to render a "show/hide" button at the top right of the container. 
+    * For now, this is only used for thrashers, which we don't want to enable our users to hide.
+   */
+  bool hideable = 9;
 }
 
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -47,8 +47,9 @@ message Collection {
   optional FollowUp follow_up = 8;
 
   /**
-    * This tells the app whether or not to render a "show/hide" button at the top right of the container. 
-    * For now, this is only used for thrashers, which we don't want to enable our users to hide.
+   * This tells the app whether or not to render a "show/hide" button at the
+   * top right of the container. For now, this is only used for thrashers,
+   *  which should not be hideable by the user. 
    */
   bool hideable = 9;
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -211,6 +211,11 @@
                 "name": "follow_up",
                 "type": "FollowUp",
                 "optional": true
+              },
+              {
+                "id": 9,
+                "name": "hideable",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
## What does this change?

This PR adds a `hideable` flag to collections. This tells the app whether or not to render a "show/hide" button at the top right of the container. For now, this is only used for thrashers, which we don't want to enable our users to hide.

See [this jira ticket](https://theguardian.atlassian.net/browse/LIVE-6050)