### PR TITLE
Make advert card type

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -297,6 +297,7 @@ message Card {
      * front placed inside a regular container alongside other cards.
      */
     CARD_TYPE_WEB_CONTENT = 8;
+    CARD_TYPE_ADVERT = 9;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -112,7 +112,8 @@ message List {
   optional string ad_targeting_path = 8;
   optional string previous_page_url = 9;
   Tracking tracking = 10;
-  repeated int32 adverts = 11;
+  // Adverts are now a card type to be used in a normal row/column
+  repeated int32 adverts = 11 [deprecated = true];
   optional MyGuardianFollow my_guardian_follow = 12;
   string id = 13;
   /**
@@ -297,6 +298,7 @@ message Card {
      * front placed inside a regular container alongside other cards.
      */
     CARD_TYPE_WEB_CONTENT = 8;
+    // The advert card type is currently only used on lists. 
     CARD_TYPE_ADVERT = 9;
   }
   CardType type = 1;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -81,6 +81,10 @@
               {
                 "name": "CARD_TYPE_WEB_CONTENT",
                 "integer": 8
+              },
+              {
+                "name": "CARD_TYPE_ADVERT",
+                "integer": 9
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -287,7 +287,13 @@
                 "id": 11,
                 "name": "adverts",
                 "type": "int32",
-                "is_repeated": true
+                "is_repeated": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 12,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.40-SNAPSHOT"
+ThisBuild / version := "0.0.41-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR introduces an "advert" card type. The native apps want to use this instead of the `adverts` field we have on lists. 

For screenshots and more information see [this corresponding MAPI PR](https://github.com/guardian/mobile-apps-api/pull/2900).