### PR TITLE
Add remaining fields to model

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -122,6 +122,11 @@ message List {
    */
   optional string web_uri = 14;
   AdTargetingParams ad_targeting_params = 15;
+  /**
+   * Needed on lists and articles. Collections use the adUnit defined
+   * in the fronts response (e.g uk/fronts/home)
+   */
+  optional string ad_unit = 16;
 }
 
 /************************* SHARED *************************/
@@ -272,6 +277,17 @@ message Article {
   // Only applicable to podcast card
   optional PodcastSeries podcast_series = 30;
   AdTargetingParams ad_targeting_params = 31;
+  /**
+   * Needed on lists and articles whereas collections use the adUnit
+   * defined in the fronts response (e.g uk/fronts/home)
+   */
+  optional string ad_unit = 32;
+  // field we get from CAPI set by the editorial team
+  bool should_hide_reader_revenue = 33;
+  // field we get from CAPI set by the editorial team
+  bool should_hide_adverts = 34;
+  // some design types (immersive/interactive) should hide the nav/tab bar
+  bool should_hide_nav = 35;
 }
 
 message Card {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -127,7 +127,7 @@ message List {
    * Needed on lists and articles. Collections use the adUnit defined
    * in the fronts response (e.g uk/fronts/home)
    */
-  optional string ad_unit = 16;
+  string ad_unit = 16;
 }
 
 /************************* SHARED *************************/

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -109,7 +109,8 @@ message List {
   repeated Row rows = 5;
   optional Branding branding = 6;
   repeated Topic topics = 7;
-  optional string ad_targeting_path = 8;
+  // use ad_unit instead 
+  optional string ad_targeting_path = 8 [deprecated = true];
   optional string previous_page_url = 9;
   Tracking tracking = 10;
   // Adverts are now a card type to be used in a normal row/column

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -270,7 +270,13 @@
                 "id": 8,
                 "name": "ad_targeting_path",
                 "type": "string",
-                "optional": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 9,

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -326,8 +326,7 @@
               {
                 "id": 16,
                 "name": "ad_unit",
-                "type": "string",
-                "optional": true
+                "type": "string"
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -316,6 +316,12 @@
                 "id": 15,
                 "name": "ad_targeting_params",
                 "type": "AdTargetingParams"
+              },
+              {
+                "id": 16,
+                "name": "ad_unit",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -841,6 +847,27 @@
                 "id": 31,
                 "name": "ad_targeting_params",
                 "type": "AdTargetingParams"
+              },
+              {
+                "id": 32,
+                "name": "ad_unit",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 33,
+                "name": "should_hide_reader_revenue",
+                "type": "bool"
+              },
+              {
+                "id": 34,
+                "name": "should_hide_adverts",
+                "type": "bool"
+              },
+              {
+                "id": 35,
+                "name": "should_hide_nav",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

For more detail see [this corresponding MAPI PR](https://github.com/guardian/mobile-apps-api/pull/2911)

- deprecate `adTargetingPath`. It is deprecated in the MAPI codebase (see [this line](https://github.com/guardian/mobile-apps-api/blob/9ecd6b0c1c228315b6c28e3c80beac5a69816be3/common-play/src/main/scala/models/contentitem/Metadata.scala#L193)) and to be replaced by `adUnit`. 
- add some missing CAPI fields (`shouldHideReaderRevenue` and `shouldHideAdverts`)
- add `shouldHideNav` for certain article types
