### PR TITLE
LIVE-6208 Add listen-to-article data to Article message

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/mss-admins

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -298,6 +298,7 @@ message Article {
   bool should_hide_adverts = 34;
   // some design types (immersive/interactive) should hide the nav/tab bar
   bool should_hide_nav = 35;
+  /**
    * It is available when the listen-to-article is supported on this article
    */
   optional ListenToArticle listen_to_article = 36;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -232,6 +232,15 @@ message RenderingPlatformSupport {
   string uri = 2;
 }
 
+/**
+ * The message provides the link to fetch the audio for listen-to-article
+ * feature on the article and other information for UI display.
+ */
+message ListenToArticle {
+  string audio_uri = 1;
+  int32 duration_in_seconds = 2;
+}
+
 message Article {
   string id = 1;
   optional string byline = 2;
@@ -289,6 +298,9 @@ message Article {
   bool should_hide_adverts = 34;
   // some design types (immersive/interactive) should hide the nav/tab bar
   bool should_hide_nav = 35;
+   * It is available when the listen-to-article is supported on this article
+   */
+  optional ListenToArticle listen_to_article = 36;
 }
 
 message Card {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -668,6 +668,21 @@
             ]
           },
           {
+            "name": "ListenToArticle",
+            "fields": [
+              {
+                "id": 1,
+                "name": "audio_uri",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "duration_in_seconds",
+                "type": "int32"
+              }
+            ]
+          },
+          {
             "name": "Article",
             "fields": [
               {
@@ -873,6 +888,12 @@
                 "id": 35,
                 "name": "should_hide_nav",
                 "type": "bool"
+              },
+              {
+                "id": 36,
+                "name": "listen_to_article",
+                "type": "ListenToArticle",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are going to run a production trial of listen-to-article feature. 

This PR adds the listen-to-article related data to the message `Article` in the schema so that MAPI can provide the native apps with the data necessary for listen-to-article feature on the blueprint responses.

## How to test

A snapshot version was published locally, and MAPI was changed and tested against this version.
