### PR TITLE
Add corresponding tags to the protobuf model

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -302,6 +302,11 @@ message Article {
    * It is available when the listen-to-article is supported on this article
    */
   optional ListenToArticle listen_to_article = 36;
+  /**
+   * The correspondingTags is to denote which of the tags that a user has
+   * selected are applied to a particular content item
+   */
+  repeated MyGuardianFollow correspondingTags = 37;
 }
 
 message Card {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -302,11 +302,6 @@ message Article {
    * It is available when the listen-to-article is supported on this article
    */
   optional ListenToArticle listen_to_article = 36;
-  /**
-   * The correspondingTags is to denote which of the tags that a user has
-   * selected are applied to a particular content item
-   */
-  repeated MyGuardianFollow corresponding_tags = 37;
 }
 
 message Card {
@@ -368,6 +363,11 @@ message Card {
    * This is the number to be used when the card type is CARD_TYPE_NUMBERED.
    */
   optional int32 card_number = 11;
+  /**
+   * The correspondingTags is to denote which of the tags that a user has
+   * selected are applied to a particular content item
+   */
+  repeated MyGuardianFollow corresponding_tags = 37;
 }
 
 message Column {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -306,7 +306,7 @@ message Article {
    * The correspondingTags is to denote which of the tags that a user has
    * selected are applied to a particular content item
    */
-  repeated MyGuardianFollow correspondingTags = 37;
+  repeated MyGuardianFollow corresponding_tags = 37;
 }
 
 message Card {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -894,6 +894,12 @@
                 "name": "listen_to_article",
                 "type": "ListenToArticle",
                 "optional": true
+              },
+              {
+                "id": 37,
+                "name": "correspondingTags",
+                "type": "MyGuardianFollow",
+                "is_repeated": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -894,12 +894,6 @@
                 "name": "listen_to_article",
                 "type": "ListenToArticle",
                 "optional": true
-              },
-              {
-                "id": 37,
-                "name": "corresponding_tags",
-                "type": "MyGuardianFollow",
-                "is_repeated": true
               }
             ]
           },
@@ -969,6 +963,12 @@
                 "name": "card_number",
                 "type": "int32",
                 "optional": true
+              },
+              {
+                "id": 37,
+                "name": "corresponding_tags",
+                "type": "MyGuardianFollow",
+                "is_repeated": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -897,7 +897,7 @@
               },
               {
                 "id": 37,
-                "name": "correspondingTags",
+                "name": "corresponding_tags",
                 "type": "MyGuardianFollow",
                 "is_repeated": true
               }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a field `correspondingTags` to the `Card` protobuf message. This is so the native apps developers can translate  the JSON response returned from the `MyGuardian Feed` endpoint into a protobuf object using this field. This is whilst the API is in a transition to migrate from using a JSON response to a protobuf response. 



