### PR TITLE
Remove advert card type in favour of indices, release major version 1

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -113,8 +113,8 @@ message List {
   optional string ad_targeting_path = 8 [deprecated = true];
   optional string previous_page_url = 9;
   Tracking tracking = 10;
-  // Adverts are now a card type to be used in a normal row/column
-  repeated int32 adverts = 11 [deprecated = true];
+  // Tells the app when rows to insert adverts before (not after!)
+  repeated int32 adverts = 11;
   optional MyGuardianFollow my_guardian_follow = 12;
   string id = 13;
   /**
@@ -328,8 +328,6 @@ message Card {
      * front placed inside a regular container alongside other cards.
      */
     CARD_TYPE_WEB_CONTENT = 8;
-    // The advert card type is currently only used on lists. 
-    CARD_TYPE_ADVERT = 9;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -81,10 +81,6 @@
               {
                 "name": "CARD_TYPE_WEB_CONTENT",
                 "integer": 8
-              },
-              {
-                "name": "CARD_TYPE_ADVERT",
-                "integer": 9
               }
             ]
           },
@@ -293,13 +289,7 @@
                 "id": 11,
                 "name": "adverts",
                 "type": "int32",
-                "is_repeated": true,
-                "options": [
-                  {
-                    "name": "deprecated",
-                    "value": "true"
-                  }
-                ]
+                "is_repeated": true
               },
               {
                 "id": 12,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.45-SNAPSHOT"
+ThisBuild / version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR essentially reverts [this PR ](https://github.com/guardian/mobile-apps-api-models/pull/62)as we want to just use indices at the list level for lists. Although breaking, this is okay as MAPI has not implemented CARD_TYPE_ADVERT, making it impossible for the client to receive this. 

## First major version!

This PR also bumps the major version to 1, our first official release. 