### PR TITLE
LIVE-6212 Add snaplink card type to blueprint schema

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -328,6 +328,12 @@ message Card {
      * front placed inside a regular container alongside other cards.
      */
     CARD_TYPE_WEB_CONTENT = 8;
+    /**
+     * A card showing a podcast series.  Internally it is represented as
+     * a snaplink with the type "link" and a link url pointing at a podcast
+     * series tag.
+     */
+    CARD_TYPE_PODCAST_SERIES = 9;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -81,6 +81,10 @@
               {
                 "name": "CARD_TYPE_WEB_CONTENT",
                 "integer": 8
+              },
+              {
+                "name": "CARD_TYPE_PODCAST_SERIES",
+                "integer": 9
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We have begun work on a new Podcast tab feature for the app.  We are looking at the novel "Current Series" collection on the design.  A sample of the design is shown below:

<img widht="320px" src="https://github.com/guardian/mobile-apps-api-models/assets/89925410/b6147f6f-0d9b-4550-a56a-4e9a891b64ae" />

On dotcom, we have similar collections which show podcast series (e.g. https://www.theguardian.com/podcasts).  The podcast series are represented in the front tools as a snaplink, which is mapped to a podcast series tag.  Currently, we do not support `SnapLink` in MAPI except interactive snaplink.  To implement this feature, we have to support it as well.

Snaplink can be used to represent [several different things](https://github.com/guardian/facia-tool/blob/main/docs/Glossary.md#snaplinks).  As the design is created for podcast series on a podcast tab, this PR adds a new card type `CARD_TYPE_PODCAST_SERIES`.

From the facia client, we can collect the following data for a podcast series snaplink:

|Field|Example|
|---|---|
|id|snap/1683116443830|
|snapType|link|
|headline (optional)|Today in Focus|
|href|/news/series/todayinfocus|
|image (optional) |Replace(https://media.guim.co.uk/4453029979df44db060528ed5f71ef19ada114eb/0_0_5000_3000/master/5000.jpg,5000,3000,None)|

Based on the current design, we probably just need *headline*, *image* and *href*.

As the message `Article` is not optional in `Card`, it may be good just to reuse `Article` for the data field for podcast series snaplink.  We may use the field `id`, `title`, `palette_light` and `palette_dark`.   We can put the podcast series link in `followUp` field of the card message.

