### PR TITLE
LIVE-6322 Add description and image to collection message

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -54,6 +54,13 @@ message Collection {
   bool hideable = 9;
 
   optional MyGuardianFollow myguardian_follow = 10;
+
+  /**
+   * For some design on specific types of collections, we want to show 
+   * an image and a description in the collection header.
+   */
+  optional string description = 11;
+  optional Image image = 12;
 }
 
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -194,6 +194,18 @@
                 "name": "myguardian_follow",
                 "type": "MyGuardianFollow",
                 "optional": true
+              },
+              {
+                "id": 11,
+                "name": "description",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "image",
+                "type": "Image",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

On the new podcast tab, there is a new design on a podcast series collection where we show the podcast series image and description in the section header.

This PR adds new fields `description` and `image` to a collection message to support this design.

<img width="720px" src="https://github.com/guardian/mobile-apps-api-models/assets/89925410/741cdb88-26c8-4cf7-80a8-aaa44e169b83" />

