### PR TITLE
Add podcast series field to card level

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -209,6 +209,9 @@ message PodcastSeries {
   string id = 1;
   string title = 2;
   string url = 3;
+  optional FollowUp follow_up = 4;
+  optional Image image = 5;
+  optional string description = 6;
 }
 
 // This message is only applicable to live blogs.
@@ -376,6 +379,11 @@ message Card {
    * This is the number to be used when the card type is CARD_TYPE_NUMBERED.
    */
   optional int32 card_number = 11;
+  /**
+   * This optional field is set if this card type is CARD_TYPE_PODCAST_SERIES.
+   * It provides the details on the podcast series.
+   */
+  optional PodcastSeries podcast_series = 12;
   /**
    * The correspondingTags is to denote which of the tags that a user has
    * selected are applied to a particular content item

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -624,6 +624,24 @@
                 "id": 3,
                 "name": "url",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "image",
+                "type": "Image",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "description",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1010,6 +1028,12 @@
                 "id": 11,
                 "name": "card_number",
                 "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "podcast_series",
+                "type": "PodcastSeries",
                 "optional": true
               },
               {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are going to support snaplink cards which point to a podcast series tag.

We discussed with native devs, and we agreed it may be a better approach to have a podcast series message on the Card level.
