### PR TITLE
Create `LayoutAgnosticCollection` for collections where the layout should be decided by the client 

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -63,58 +63,6 @@ message Collection {
   optional Image image = 12;
 }
 
-message CollectionGridDedupeSpike {
-  string id = 1;
-  /**
-   * A palette at the collection level is currently mapped from MAPI's
-   * "navigation style". It's specified when the look and feel of an entire
-   * container should be changed, for example when a container is "branded"
-   * because the content has been paid for.
-   */
-  optional Palette palette_light = 2;
-  optional Palette palette_dark = 3;
-  /**
-   * MAPI can technically return a list of empty rows. This might be because
-   * MAPI doesn't support the specific content that's included in the
-   * collection. In this case it's assumed the client will hide the entire
-   * collection from the reader.
-   */
-  repeated Card cards = 4;
-  optional string title = 5;
-  /**
-   * We define branding at the collection level because certain containers
-   * require a different look and feel, for example content published by
-   * Guardian Labs.
-   */
-  optional Branding branding = 6;
-  /**
-   * A container can be defined as "premium". Currently this is just for the
-   * Crosswords container for which only premium users are allowed to access
-   * (although it is visible to all users). Note that the Crosswords
-   * container is not curated by Editorial in the fronts tool but instead
-   * created on the fly by MAPI.
-   */
-  optional bool premium_content = 7;
-  optional FollowUp follow_up = 8;
-
-  /**
-   * This tells the app whether or not to render a "show/hide" button at the
-   * top right of the container. For now, this is only used for thrashers,
-   *  which should not be hideable by the user.
-   */
-  bool hideable = 9;
-
-  optional MyGuardianFollow myguardian_follow = 10;
-
-  /**
-   * For some design on specific types of collections, we want to show
-   * an image and a description in the collection header.
-   */
-  optional string description = 11;
-  optional Image image = 12;
-}
-
-
 /**
  * The follow up message contains links to get more information about the
  * collection.
@@ -189,6 +137,39 @@ message List {
    */
   string ad_unit = 16;
 }
+
+/************************* MY GUARDIAN *************************/
+
+// The following messages are used only to model the contents of our
+// My Guardian endpoints (grid, feed etc)
+
+/**
+  * This message type is similar to Collection but with less information. 
+  * It will be used when the client will decide how to lay out
+  * the collection instead of the server. This is useful for My Guardian
+  * where the client will need to deduplicate the content from multiple 
+  * collections.
+  */
+message LayoutAgnosticCollection {
+  string id = 1;
+  /**
+    * A palette at the collection level is currently mapped from MAPI's
+    * "navigation style". It's specified when the look and feel of an entire
+    * container should be changed, for example when a container is "branded"
+    * because the content has been paid for.
+    */
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  /**
+    * Here we return a list of cards instead of rows. This means that 
+    * the client will need to decide how to layout the cards.
+    */
+  repeated Card cards = 4;
+  optional string title = 5;
+  optional FollowUp follow_up = 6;
+}
+  
+  
 
 /************************* SHARED *************************/
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -63,6 +63,57 @@ message Collection {
   optional Image image = 12;
 }
 
+message CollectionGridDedupeSpike {
+  string id = 1;
+  /**
+   * A palette at the collection level is currently mapped from MAPI's
+   * "navigation style". It's specified when the look and feel of an entire
+   * container should be changed, for example when a container is "branded"
+   * because the content has been paid for.
+   */
+  optional Palette palette_light = 2;
+  optional Palette palette_dark = 3;
+  /**
+   * MAPI can technically return a list of empty rows. This might be because
+   * MAPI doesn't support the specific content that's included in the
+   * collection. In this case it's assumed the client will hide the entire
+   * collection from the reader.
+   */
+  repeated Card cards = 4;
+  optional string title = 5;
+  /**
+   * We define branding at the collection level because certain containers
+   * require a different look and feel, for example content published by
+   * Guardian Labs.
+   */
+  optional Branding branding = 6;
+  /**
+   * A container can be defined as "premium". Currently this is just for the
+   * Crosswords container for which only premium users are allowed to access
+   * (although it is visible to all users). Note that the Crosswords
+   * container is not curated by Editorial in the fronts tool but instead
+   * created on the fly by MAPI.
+   */
+  optional bool premium_content = 7;
+  optional FollowUp follow_up = 8;
+
+  /**
+   * This tells the app whether or not to render a "show/hide" button at the
+   * top right of the container. For now, this is only used for thrashers,
+   *  which should not be hideable by the user.
+   */
+  bool hideable = 9;
+
+  optional MyGuardianFollow myguardian_follow = 10;
+
+  /**
+   * For some design on specific types of collections, we want to show
+   * an image and a description in the collection header.
+   */
+  optional string description = 11;
+  optional Image image = 12;
+}
+
 
 /**
  * The follow up message contains links to get more information about the

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -246,81 +246,6 @@
             ]
           },
           {
-            "name": "CollectionGridDedupeSpike",
-            "fields": [
-              {
-                "id": 1,
-                "name": "id",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "palette_light",
-                "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 3,
-                "name": "palette_dark",
-                "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 4,
-                "name": "cards",
-                "type": "Card",
-                "is_repeated": true
-              },
-              {
-                "id": 5,
-                "name": "title",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 6,
-                "name": "branding",
-                "type": "Branding",
-                "optional": true
-              },
-              {
-                "id": 7,
-                "name": "premium_content",
-                "type": "bool",
-                "optional": true
-              },
-              {
-                "id": 8,
-                "name": "follow_up",
-                "type": "FollowUp",
-                "optional": true
-              },
-              {
-                "id": 9,
-                "name": "hideable",
-                "type": "bool"
-              },
-              {
-                "id": 10,
-                "name": "myguardian_follow",
-                "type": "MyGuardianFollow",
-                "optional": true
-              },
-              {
-                "id": 11,
-                "name": "description",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 12,
-                "name": "image",
-                "type": "Image",
-                "optional": true
-              }
-            ]
-          },
-          {
             "name": "FollowUp",
             "fields": [
               {
@@ -450,6 +375,46 @@
                 "id": 16,
                 "name": "ad_unit",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "LayoutAgnosticCollection",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "palette_light",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "palette_dark",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "cards",
+                "type": "Card",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -246,6 +246,81 @@
             ]
           },
           {
+            "name": "CollectionGridDedupeSpike",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "palette_light",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "palette_dark",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "cards",
+                "type": "Card",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "title",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "branding",
+                "type": "Branding",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "premium_content",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "hideable",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "myguardian_follow",
+                "type": "MyGuardianFollow",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "description",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "image",
+                "type": "Image",
+                "optional": true
+              }
+            ]
+          },
+          {
             "name": "FollowUp",
             "fields": [
               {


### PR DESCRIPTION
Co-authored @lindseydew  @tkgnm 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are investigating ways of being able to deduplicate cards across My Guardian collections. As a result of this [investigation](https://docs.google.com/document/d/1jhBPoG4tZgvfaR85x1gWH0DOSCNYbmivp4-O9e1Y2ao/edit) we are exploring option 2 where the client performs the deduping instead of the server. 

As a result, we require an API endpoint which returns the content as a list of cards without any layout specified, to enable the client to dedupe and then build the correct layout.

To that end, this PR introduces `LayoutAgnosticCollection` which returns the same response as `Collection` except instead of returns rows which describe a layout, we return a flat list of cards. Some other unnecessary fields (such as `thrasher`, `branding`) have also been removed. If we find that we do need these, we can always add them back in as a non-breaking change. 

## How to test

@tkgnm has spiked this for iOS and can confirm this is a good solution between the server and the client. 
