### PR TITLE
Add collection type

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -61,6 +61,13 @@ message Collection {
    */
   optional string description = 11;
   optional Image image = 12;
+
+  enum CollectionType {
+    COLLECTION_TYPE_UNSPECIFIED = 0;
+    COLLECTION_TYPE_REGULAR = 1;
+    COLLECTION_TYPE_PODCAST = 2;
+  }
+  optional CollectionType type = 13;
 }
 
 /**

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -62,12 +62,15 @@ message Collection {
   optional string description = 11;
   optional Image image = 12;
 
-  enum CollectionType {
-    COLLECTION_TYPE_UNSPECIFIED = 0;
-    COLLECTION_TYPE_REGULAR = 1;
-    COLLECTION_TYPE_PODCAST = 2;
+  /**
+   * This tells the app which design to use to render the collection
+   */ 
+  enum CollectionDesign {
+    COLLECTION_DESIGN_UNSPECIFIED = 0;
+    COLLECTION_DESIGN_REGULAR = 1;
+    COLLECTION_DESIGN_PODCAST = 2;
   }
-  optional CollectionType type = 13;
+  optional CollectionDesign design = 13;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -5,6 +5,22 @@
       "def": {
         "enums": [
           {
+            "name": "Collection.CollectionType",
+            "enum_fields": [
+              {
+                "name": "COLLECTION_TYPE_UNSPECIFIED"
+              },
+              {
+                "name": "COLLECTION_TYPE_REGULAR",
+                "integer": 1
+              },
+              {
+                "name": "COLLECTION_TYPE_PODCAST",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "FollowUp.FollowUpType",
             "enum_fields": [
               {
@@ -241,6 +257,12 @@
                 "id": 12,
                 "name": "image",
                 "type": "Image",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "type",
+                "type": "CollectionType",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -5,17 +5,17 @@
       "def": {
         "enums": [
           {
-            "name": "Collection.CollectionType",
+            "name": "Collection.CollectionDesign",
             "enum_fields": [
               {
-                "name": "COLLECTION_TYPE_UNSPECIFIED"
+                "name": "COLLECTION_DESIGN_UNSPECIFIED"
               },
               {
-                "name": "COLLECTION_TYPE_REGULAR",
+                "name": "COLLECTION_DESIGN_REGULAR",
                 "integer": 1
               },
               {
-                "name": "COLLECTION_TYPE_PODCAST",
+                "name": "COLLECTION_DESIGN_PODCAST",
                 "integer": 2
               }
             ]
@@ -261,8 +261,8 @@
               },
               {
                 "id": 13,
-                "name": "type",
-                "type": "CollectionType",
+                "name": "design",
+                "type": "CollectionDesign",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In the podcast tab design, we show a "Show more episodes" link at the bottom of a podcast series collection.  This link goes to the tag page for the podcast, which is in `followUp` field of the MAPI response.

<img width="320px" src="https://github.com/guardian/mobile-apps-api-models/assets/89925410/1144587a-35fe-4a82-89a4-dfd61ebaf4c5" />

We don't have this link for regular collections though clicking on the title of a collection can take users to the `followUp` page.

This PR adds a field `collectionType` to the `Collection` message to tell the apps whether to render the collection using the podcast tab design (i.e. with the "show more episodes" link at the bottom) or the regular collection design. 
