### PR TITLE
Add a card type and a collection design for new masthead design

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -69,6 +69,7 @@ message Collection {
     COLLECTION_DESIGN_UNSPECIFIED = 0;
     COLLECTION_DESIGN_REGULAR = 1;
     COLLECTION_DESIGN_PODCAST = 2;
+    COLLECTION_DESIGN_TITLEPIECE = 3;
   }
   optional CollectionDesign design = 13;
 }

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -27,6 +27,9 @@ message Collection {
    * MAPI doesn't support the specific content that's included in the
    * collection. In this case it's assumed the client will hide the entire
    * collection from the reader.
+   * Another reason for empty rows is that the collection is a titlepiece.
+   * In fact, we must keep the rows empty in this case in order not to break
+   * old versions of app that were built before titlepiece is introduced.
    */
   repeated Row rows = 4;
   optional string title = 5;
@@ -57,7 +60,9 @@ message Collection {
 
   /**
    * For some design on specific types of collections, we want to show 
-   * an image and a description in the collection header.
+   * an image and a description in the collection header.  This field is
+   * used for award text if the collection design is 
+   * COLLECTION_DESIGN_TITLEPIECE.
    */
   optional string description = 11;
   optional Image image = 12;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -388,6 +388,11 @@ message Card {
      * series tag.
      */
     CARD_TYPE_PODCAST_SERIES = 9;
+    /**
+     * A card with a different design.  It is intended for highlights
+     * containers.
+     */
+    CARD_TYPE_HIGHLIGHT = 10;
   }
   CardType type = 1;
   Article article = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -101,6 +101,10 @@
               {
                 "name": "CARD_TYPE_PODCAST_SERIES",
                 "integer": 9
+              },
+              {
+                "name": "CARD_TYPE_HIGHLIGHT",
+                "integer": 10
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -17,6 +17,10 @@
               {
                 "name": "COLLECTION_DESIGN_PODCAST",
                 "integer": 2
+              },
+              {
+                "name": "COLLECTION_DESIGN_TITLEPIECE",
+                "integer": 3
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In the new homepage design, the masthead is split into two parts (top bar and titlepiece) with a new highlights container between them.  

<img width="320px" src="https://github.com/guardian/mobile-apps-api-models/assets/89925410/314a897e-bf4f-4df4-8f88-38bd7454cf8d" />

The highlights container has new design on its cards. We also want to model the titlepiece as a collection in blueprint responses.

This PR extends the MAPI data model to support the new design by
- adding a new card type `CARD_TYPE_HIGHLIGHTS` for the card inside highlights
- adding a new collection design `COLLECTION_DESIGN_TITLEPIECE` for the titlepiece container