### PR TITLE
Add `kicker_colour` to `palette`

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -203,6 +203,12 @@ message Palette {
   string secondary = 13;
   string shadow = 14;
   string top_border = 15;
+  /*
+   * Used for kicker text colour post Fairground updates. For Live cards,
+   * `pill` colour provides the background and `kicker_text` is the text
+   * colour.
+   */
+  string kicker_text = 16;
 }
 
 message Links {
@@ -538,4 +544,3 @@ message BasicTag {
   string id = 1;
   string web_title = 2;
 }
-

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -517,6 +517,11 @@
                 "id": 15,
                 "name": "top_border",
                 "type": "string"
+              },
+              {
+                "id": 16,
+                "name": "kicker_text",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of project fairground changes, the Live card kickers are changing to become a pill shape. This requires two colours - one for the pill background, another for kicker text colour.
We've decided to use the existing `pill` property for the background colour, and a new `kicker_colour` for the text (and pulsing dot) colour.

![Before & after live cards](https://github.com/guardian/mobile-apps-api-models/assets/79363218/52abc9a1-4b4d-4fdb-84bc-270f28dd6348)

Why not use the existing `accent_colour`. 
At the moment, kickers use `accent_colour`. But when we roll out the server side changes, the value of kicker text colour will change from pillar colour (news red / sports blue) to white. Alongside this, the background colour of live cards will also change from pillar to white. For updated apps, this is fine because the text will be wrapped in a pill. But on non-updated app versions, this will result in a white kicker text on white card background.
To avoid this, we've chosen to use a new named colour property for kicker text in the upgraded cards. This also has the benefit of being semantically named instead of the ambiguous `accent_colour`.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
