### PR TITLE
Add mega-boost attribute to card

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -412,8 +412,7 @@ message Card {
   CardType type = 1;
   Article article = 2;
   /**
-   * Boosted cards show a boosted headline size and a main image that spans
-   * full width on mobile.
+   * Boosted cards show a boosted headline size.
    */
   optional bool boosted = 3;
   /**
@@ -451,6 +450,10 @@ message Card {
    * selected are applied to a particular content item
    */
   repeated MyGuardianFollow corresponding_tags = 37;
+  /**
+   * Mega-boosted cards show a even larger headline size.
+   */
+  optional bool mega_boosted = 38;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1134,6 +1134,12 @@
                 "name": "corresponding_tags",
                 "type": "MyGuardianFollow",
                 "is_repeated": true
+              },
+              {
+                "id": 38,
+                "name": "mega_boosted",
+                "type": "bool",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the homepage redesign project, we are implementing the redesigned dynamic package layout.

In the new design, we will have a new option named `mega boost` for cards in the front tool.  If this option is selected, the card will have an even bigger headline.  In new dynamic package layout, only the first card in the standard group can have this option.  

This PR adds a field `mega_boosted` on the `Card` message to indicate that this card is mega-boosted.