### PR TITLE
[fairground] Add attributes to adjust the spacing in collections and rows

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -504,7 +504,7 @@ message Row {
    * When this attribute is true, the spacing in between cards in the row is 
    * reduced.
    */
-  optional bool has_tight_spacing = 8;
+  optional bool tighten_spacing = 8;
 }
 
 message Topic {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -77,6 +77,12 @@ message Collection {
     COLLECTION_DESIGN_TITLEPIECE = 3;
   }
   optional CollectionDesign design = 13;
+
+  /**
+   * When this attribute is true, the vertical spacing is removed from 
+   * the collection.
+   */
+  optional bool compact_padding = 14;
 }
 
 /**
@@ -493,6 +499,12 @@ message Row {
   optional Thrasher thrasher = 5;
   RowType type = 6;
   optional string title = 7;
+
+  /**
+   * When this attribute is true, the spacing in between cards in the row is 
+   * reduced.
+   */
+  optional bool has_tight_spacing = 8;
 }
 
 message Topic {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -272,6 +272,12 @@
                 "name": "design",
                 "type": "CollectionDesign",
                 "optional": true
+              },
+              {
+                "id": 14,
+                "name": "compact_padding",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -1212,6 +1218,12 @@
                 "id": 7,
                 "name": "title",
                 "type": "string",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "has_tight_spacing",
+                "type": "bool",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1222,7 +1222,7 @@
               },
               {
                 "id": 8,
-                "name": "has_tight_spacing",
+                "name": "tighten_spacing",
                 "type": "bool",
                 "optional": true
               }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The highlights collection introduced as part of the homepage redesign work has less spacing around the collection and in between cards.

This PR adds the following attributes to indicate it:
1. `hasTightSpacing` on a `Row` reduces the spacing in between cards on this row
2. `compactPadding` on a `Collection` reduces the padding around the collection