### PR TITLE
Add a field for the ID of the collection to be used in tracking data

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -83,6 +83,12 @@ message Collection {
    * the collection.
    */
   optional bool compact_padding = 14;
+
+  /**
+   * The property gives the ID of the collection to be used in 
+   * the tracking data.
+   */
+  optional string tracking_id = 15;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -278,6 +278,12 @@
                 "name": "compact_padding",
                 "type": "bool",
                 "optional": true
+              },
+              {
+                "id": 15,
+                "name": "tracking_id",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

For tracking front container views and clicks on the cards in Ophan, we use the container’s title as part of component id: <front.title>-<container.title>.   Highlight containers don’t have a title, so the component id appears as home-.

To address this, and to reduce the reliance on converting titles to ids natively, we want to add a new property to blueprint collection response - trackingId - which can be used to directly track the container to Ophan.
