### PR TITLE
[fairground] Add tracking ID to layout agnostic collection

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -195,6 +195,12 @@ message LayoutAgnosticCollection {
   repeated Card cards = 4;
   optional string title = 5;
   optional FollowUp follow_up = 6;
+
+  /**
+   * The property gives the ID of the collection to be used in 
+   * the tracking data.
+   */
+  optional string tracking_id = 7;
 }
   
   

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -457,6 +457,12 @@
                 "name": "follow_up",
                 "type": "FollowUp",
                 "optional": true
+              },
+              {
+                "id": 7,
+                "name": "tracking_id",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The previous PR #91 added a field to `Collection` for the ID of this collection in tracking data.

This PR adds a similar field to `LayoutAgnosticCollection`.