### PR TITLE
Add small heading indicator to collection

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -89,6 +89,13 @@ message Collection {
    * the tracking data.
    */
   optional string tracking_id = 15;
+
+  /**
+   * The property is added when we build small story carousel where
+   * the header is rendered in smaller size to show they are child
+   * sections within a main collection.
+   */
+  optional bool small_heading = 16;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -284,6 +284,12 @@
                 "name": "tracking_id",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 16,
+                "name": "small_heading",
+                "type": "bool",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are building the new small story carousel layout as part of the homepage redesign project.  The design are shown below:

| Mobile | Tablet |
| --- | --- |
| <img width="180px" src="https://github.com/user-attachments/assets/badbf4ac-6d49-487a-803c-fefba8af809a" /> | <img width="360px" src="https://github.com/user-attachments/assets/c6509640-b127-4ece-89ac-0e80ce705ad2" /> |

The small story carousel should be rendered with a smaller heading than other layouts.

This PR adds an attribute `small_heading` to collection schema to indicate this design.

