### PR TITLE
Add description field to list model 

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -171,6 +171,7 @@ message List {
    * in the fronts response (e.g uk/fronts/home)
    */
   string ad_unit = 16;
+  optional string description = 17;
 }
 
 /************************* MY GUARDIAN *************************/

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -507,6 +507,12 @@
                 "id": 16,
                 "name": "ad_unit",
                 "type": "string"
+              },
+              {
+                "id": 17,
+                "name": "description",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
## What does this change?

Adds optional description field to the list model. This is originally defined in Tag Manager for each tag and gets returned through CAPI. 

## Why

Some list views (such as author and series pages) carry a description when viewed on our website (mobile and desktop).

Historically, these descriptions have not featured in the app; they have simply been omitted.

This is problematic editorially, as these descriptions contain important context about the author or series that app users currently lose.

The purpose of this change is to add these descriptions to the list model so the app can display them and achieve editorial parity with the website
