### PR TITLE
[FGND] Add gallery image count to `Card`

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -565,7 +565,10 @@ message Card {
 
   optional int32 boost_level = 45;
   
-  /** Number of images in a gallery card. This is only useful when the media type is MEDIA_TYPE_IMAGE. */
+  /** 
+   * Number of images in a gallery card. This is used to display gallery 
+   * metadata on card when the media type is MEDIA_TYPE_IMAGE. 
+   */
   optional int32 gallery_image_count = 46;
 }
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -564,6 +564,9 @@ message Card {
   optional CardSize card_size = 44;
 
   optional int32 boost_level = 45;
+  
+  /** Number of images in a gallery card. This is only useful when the media type is MEDIA_TYPE_IMAGE. */
+  optional int32 gallery_image_count = 46;
 }
 
 message Column {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -401,7 +401,7 @@ message Article {
    * Number of images in a gallery card. This is used to display gallery 
    * metadata on card when the media_type is MEDIA_TYPE_IMAGE. 
    */
-  optional int32 gallery_image_count = 46;
+  optional int32 gallery_image_count = 37;
 }
 
 message Card {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -396,6 +396,12 @@ message Article {
    * It is available when the listen-to-article is supported on this article
    */
   optional ListenToArticle listen_to_article = 36;
+  
+  /** 
+   * Number of images in a gallery card. This is used to display gallery 
+   * metadata on card when the media_type is MEDIA_TYPE_IMAGE. 
+   */
+  optional int32 gallery_image_count = 46;
 }
 
 message Card {
@@ -564,12 +570,6 @@ message Card {
   optional CardSize card_size = 44;
 
   optional int32 boost_level = 45;
-  
-  /** 
-   * Number of images in a gallery card. This is used to display gallery 
-   * metadata on card when the media type is MEDIA_TYPE_IMAGE. 
-   */
-  optional int32 gallery_image_count = 46;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1330,6 +1330,12 @@
                 "name": "boost_level",
                 "type": "int32",
                 "optional": true
+              },
+              {
+                "id": 46,
+                "name": "gallery_image_count",
+                "type": "int32",
+                "optional": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1201,6 +1201,12 @@
                 "name": "listen_to_article",
                 "type": "ListenToArticle",
                 "optional": true
+              },
+              {
+                "id": 46,
+                "name": "gallery_image_count",
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -1328,12 +1334,6 @@
               {
                 "id": 45,
                 "name": "boost_level",
-                "type": "int32",
-                "optional": true
-              },
-              {
-                "id": 46,
-                "name": "gallery_image_count",
                 "type": "int32",
                 "optional": true
               }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1203,7 +1203,7 @@
                 "optional": true
               },
               {
-                "id": 46,
+                "id": 37,
                 "name": "gallery_image_count",
                 "type": "int32",
                 "optional": true


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new property to `Article` model for the number of images in a gallery. This allows displaying this count in the gallery pill on cards.

Figma: https://www.figma.com/design/kSmjgtoTWiG8N7HXxFoGEE/%E2%97%90-Apps-library?node-id=5245-764&node-type=frame&t=GOWCl1sJcbiISp1k-11

