### PR TITLE
Update the blueprint proto file with some iOS changes

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -437,8 +437,9 @@ message Card {
   }
   CardType type = 1;
   /**
-    The article that this card is representing. It is optional because not all cards
-    will have an article associated with them i.e Crosswords.
+    The article that this card is representing. It is optional 
+    because not all cards will have an article associated with 
+    them i.e Crosswords or Web content.
   */
   optional Article article = 2;
   /**

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -5,7 +5,8 @@ package com.gu.mobile.mapi.models.v0;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option swift_prefix="Blueprint";
+// A prefix only used for the Swift models
+option swift_prefix="Proto";
 
 /************************* COLLECTION *************************/
 
@@ -435,7 +436,11 @@ message Card {
     CARD_TYPE_HIGHLIGHT = 10;
   }
   CardType type = 1;
-  Article article = 2;
+  /**
+    The article that this card is representing. It is optional because not all cards
+    will have an article associated with them i.e Crosswords.
+  */
+  optional Article article = 2;
   /**
    * Boosted cards show a boosted headline size.
    */

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1215,7 +1215,8 @@
               {
                 "id": 2,
                 "name": "article",
-                "type": "Article"
+                "type": "Article",
+                "optional": true
               },
               {
                 "id": 3,
@@ -1568,7 +1569,7 @@
         "options": [
           {
             "name": "swift_prefix",
-            "value": "Blueprint"
+            "value": "Proto"
           }
         ]
       }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This updates the Swift prefix, which is used by the iOS tooling to generate the Swift files. And makes the `article` on a `Card` `optional` because even though it is currently marked as not optional there are a few cases where it is not provided and an unpopulated article is being used. This is less helpful than just declaring this as optional.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The article optionality change may have some affect on how cards are used.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Again the article optionality change may have some affect on how cards are used but this is a better representation of a `Card` 
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
