### PR TITLE
Add commercial fields to the blueprint response

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -97,6 +97,10 @@ message Collection {
    * sections within a main collection.
    */
   optional bool small_heading = 16;
+
+  optional AdTargetingParams ad_targeting_params = 17;
+
+  optional string ad_unit = 18;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -414,6 +414,18 @@
                 "name": "small_heading",
                 "type": "bool",
                 "optional": true
+              },
+              {
+                "id": 17,
+                "name": "ad_targeting_params",
+                "type": "AdTargetingParams",
+                "optional": true
+              },
+              {
+                "id": 18,
+                "name": "ad_unit",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds the ad_targeting_params and ad_unit field to blueprint collections response as currently we are serving these in the legacy collections endpoint, but not in the new blueprint one. These fields are needed for advertising

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
