### PR TITLE
[Fairground] Add a property to indicate the heading style.  Replace the title property.

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -96,11 +96,30 @@ message Collection {
    * the header is rendered in smaller size to show they are child
    * sections within a main collection.
    */
-  optional bool small_heading = 16;
+  optional bool small_heading = 16 [deprecated = true];
 
   optional AdTargetingParams ad_targeting_params = 17;
 
   optional string ad_unit = 18;
+
+  /**
+   * This tells the app in which style to display, or not display,
+   * the title.
+   */ 
+  enum HeadingStyle {
+    HEADING_STYLE_UNSPECIFIED = 0;
+    HEADING_STYLE_HIDDEN = 1;
+    HEADING_STYLE_REGULAR = 2;
+    HEADING_STYLE_SMALL = 3;
+  }
+  optional HeadingStyle heading_style = 19;
+
+  /**
+   * The title of this collection for display.  It replaces 
+   * the old "title" property.
+   */
+  optional string display_title = 20;
+
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -25,6 +25,26 @@
             ]
           },
           {
+            "name": "Collection.HeadingStyle",
+            "enum_fields": [
+              {
+                "name": "HEADING_STYLE_UNSPECIFIED"
+              },
+              {
+                "name": "HEADING_STYLE_HIDDEN",
+                "integer": 1
+              },
+              {
+                "name": "HEADING_STYLE_REGULAR",
+                "integer": 2
+              },
+              {
+                "name": "HEADING_STYLE_SMALL",
+                "integer": 3
+              }
+            ]
+          },
+          {
             "name": "FollowUp.FollowUpType",
             "enum_fields": [
               {
@@ -413,7 +433,13 @@
                 "id": 16,
                 "name": "small_heading",
                 "type": "bool",
-                "optional": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 17,
@@ -424,6 +450,18 @@
               {
                 "id": 18,
                 "name": "ad_unit",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 19,
+                "name": "heading_style",
+                "type": "HeadingStyle",
+                "optional": true
+              },
+              {
+                "id": 20,
+                "name": "display_title",
                 "type": "string",
                 "optional": true
               }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We have to support at least three styles for a collection title for the new design of the homepage: 
1. hidden (for example, in highlights)
2. in regular size
3. in small size (for example, in small story carousels)

Previously, we tell the apps to hide the title by not populating the `title` property.  However, we found that we need to show title elsewhere (for example, homepage customisation page) even if we don't show it on the front.

After discussion, we agree to create a new property to indicate in what style to display the title.  In this schema, we should always provide the title.  We have to add a new title property and deprecate the existing one in order not to break the existing version of the app.
