### PR TITLE
Mark link fields as optional

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -267,10 +267,10 @@ message Palette {
 }
 
 message Links {
-  string related_uri = 1;
-  string short_url = 2;
+  optional string related_uri = 1;
+  optional string short_url = 2;
   string uri = 3;
-  string web_uri = 4;
+  optional string web_uri = 4;
 }
 
 enum MediaType {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -737,12 +737,14 @@
               {
                 "id": 1,
                 "name": "related_uri",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "short_url",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
@@ -752,7 +754,8 @@
               {
                 "id": 4,
                 "name": "web_uri",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I've made a few fields in the `Link` message optional as we find these are omitted in some case like Crosswords.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
