### PR TITLE
[Fairground] Add programmatic carousel row type

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -647,6 +647,11 @@ message Row {
      * when thrashers are displayed inside a fixed/thrasher container.
      */
     ROW_TYPE_WEB_CONTENT = 3;
+    /**
+     * New carousel style on some new collection types such as 
+     * small story carousel on tablet
+     */
+    ROW_TYPE_PROGRAMMATIC_CAROUSEL = 4;
   }
   repeated Column columns = 1;
   optional Palette palette_light = 2;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -273,6 +273,10 @@
               {
                 "name": "ROW_TYPE_WEB_CONTENT",
                 "integer": 3
+              },
+              {
+                "name": "ROW_TYPE_PROGRAMMATIC_CAROUSEL",
+                "integer": 4
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the homepage redesign project, we are building a new collection type named small story carousel on the apps.

On the tablet design, we have a new style of carousel as shown below:

![Screenshot 2024-10-07 at 18 15 39](https://github.com/user-attachments/assets/5d5751ae-1905-4e04-a148-51538f944188)

We only apply this design on carousels in the small story carousel and some other new collection types, but we want to keep the old design on highlights and existing collection types.

Therefore, we need to indicate to the apps to render this carousel design via the MAPI response, and we agree to add a new row type `ROW_TYPE_PROGRAMMATIC_CAROUSEL` for this purpose.
