### PR TITLE
Add basic tag to models

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -420,12 +420,14 @@ message Article {
    * It is available when the listen-to-article is supported on this article
    */
   optional ListenToArticle listen_to_article = 36;
-  
-  /** 
-   * Number of images in a gallery card. This is used to display gallery 
-   * metadata on card when the media_type is MEDIA_TYPE_IMAGE. 
+
+  /**
+   * Number of images in a gallery card. This is used to display gallery
+   * metadata on card when the media_type is MEDIA_TYPE_IMAGE.
    */
   optional int32 gallery_image_count = 37;
+
+  repeated BasicTag basic_tags = 38;
 }
 
 message Card {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1264,6 +1264,12 @@
                 "name": "gallery_image_count",
                 "type": "int32",
                 "optional": true
+              },
+              {
+                "id": 38,
+                "name": "basic_tags",
+                "type": "BasicTag",
+                "is_repeated": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The native devs would like to run an experiment which recommends articles based on the tags it associated with. This is adding it to the model so it can be output in the serverside response.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
