### PR TITLE
[Fairground] Add follow up object to rows

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -672,6 +672,12 @@ message Row {
    * reduced.
    */
   optional bool tighten_spacing = 8;
+
+  /**
+   * Clicking the row title takes users to the page indicated by 
+   * this attribute.  The row title is not clickable if it is empty. 
+   */
+  optional FollowUp follow_up = 9;
 }
 
 message Topic {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1515,6 +1515,12 @@
                 "name": "tighten_spacing",
                 "type": "bool",
                 "optional": true
+              },
+              {
+                "id": 9,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are building small story carousels as part of the fairground project.

Due to the new carousel design on tablet, we raised a PR #113 to add a new row type for this.  On the new design, we also have a pair of arrow buttons on the heading to control the scrolling instead of swiping to scroll.  

Therefore, we need to render the heading as the row title and add the follow-up object to rows to indicate the destination page which the apps should take to if the row title is clicked.

This pull request adds the `FollowUp` object to `Row`.