### PR TITLE
[Fairground] Add heading style and tracking ID to Row

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -683,6 +683,15 @@ message Row {
    * this attribute.  The row title is not clickable if it is empty. 
    */
   optional FollowUp follow_up = 9;
+
+  /** Control the style of the title on row level */
+  optional Collection.HeadingStyle heading_style = 10;
+
+  /**
+   * The property gives the ID for tracking data which is sent by
+   * the apps when users tap the row title.
+   */
+  optional string tracking_id = 11;
 }
 
 message Topic {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1539,6 +1539,18 @@
                 "name": "follow_up",
                 "type": "FollowUp",
                 "optional": true
+              },
+              {
+                "id": 10,
+                "name": "heading_style",
+                "type": "Collection.HeadingStyle",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "tracking_id",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

On the new `scrollable/small` and `scrollable/medium` collections, we display the title on row level instead of collection level.  Users can tap the title and the apps will take them to the front or tag page as dictated by the `FollowUp` property.

When users tap on a collection title, the apps will send a tracking event to Ophan with a tracking ID which is created based on the title.  We need a similar tracking ID for row title.

In addition, we are required to show the row title in regular size or in small size, depending on whether the collection is primary or secondary.  So we need to indicate in which style we should render row the title.

This pull request add these two properties, `trackingId` and `headingStyle`, to `Row` message type for these two purposes.