### PR TITLE
[Fairground] Add top border style to Card

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -627,6 +627,17 @@ message Card {
    * Indicate how sublinks are arranged.
    */
   optional SublinksArrangement preferred_sublinks_arrangement = 46;
+
+  /**
+   * Control how the top border is displayed.
+   */
+  optional TopBorderStyle top_border_style = 47;
+}
+
+enum TopBorderStyle {
+  TOP_BORDER_STYLE_UNSPECIFIED = 0;
+  TOP_BORDER_STYLE_HIDDEN = 1;
+  TOP_BORDER_STYLE_REGULAR = 2;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -257,6 +257,22 @@
             ]
           },
           {
+            "name": "TopBorderStyle",
+            "enum_fields": [
+              {
+                "name": "TOP_BORDER_STYLE_UNSPECIFIED"
+              },
+              {
+                "name": "TOP_BORDER_STYLE_HIDDEN",
+                "integer": 1
+              },
+              {
+                "name": "TOP_BORDER_STYLE_REGULAR",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "Row.RowType",
             "enum_fields": [
               {
@@ -1453,6 +1469,12 @@
                 "id": 46,
                 "name": "preferred_sublinks_arrangement",
                 "type": "SublinksArrangement",
+                "optional": true
+              },
+              {
+                "id": 47,
+                "name": "top_border_style",
+                "type": "TopBorderStyle",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

According to the design of small/medium story carousel, we should not display the top border above cards in these collections.

<img width="360px" src="https://github.com/user-attachments/assets/588e546b-e930-469c-87ff-6c1cc4bc3297" />

While we have a property for the colour of top border on card level, we cannot simply set it to zero opacity due to the extra padding of the invisible header.

Therefore we raise this pull request to add a property to card to control the style of the top border above the card.  Enum is used as the data type to make it extensible as we may need to have finer control over the top border.