### PR TITLE
[Fairground] Deprecate HeadingStyle enum defined on Collection level in favour of TitleStyle on top level

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -104,7 +104,8 @@ message Collection {
 
   /**
    * This tells the app in which style to display, or not display,
-   * the title.
+   * the title.  It should not be used any more as a new equivalent
+   * enum class named "TitleStyle" is defined on the top level.
    */ 
   enum HeadingStyle {
     HEADING_STYLE_UNSPECIFIED = 0;
@@ -112,6 +113,11 @@ message Collection {
     HEADING_STYLE_REGULAR = 2;
     HEADING_STYLE_SMALL = 3;
   }
+  /**
+   * This property is deprecated in favour of the property title_style.
+   * We still set this property to the same semantic value as
+   * the title style for backward compatibility.
+   */
   optional HeadingStyle heading_style = 19;
 
   /**
@@ -121,6 +127,11 @@ message Collection {
   optional string display_title = 20;
   
   optional google.protobuf.Timestamp last_updated_date = 21;
+
+  /**
+   * Control in what style to display the collection title.
+   */
+  optional TitleStyle title_style = 22;
 }
 
 /**
@@ -340,6 +351,16 @@ message Branding {
   string label = 5;
   string about_uri = 6;
   optional string alt_logo = 7;
+}
+
+/**
+  * Control in what style to display a title.
+  */ 
+enum TitleStyle {
+  TITLE_STYLE_UNSPECIFIED = 0;
+  TITLE_STYLE_HIDDEN = 1;
+  TITLE_STYLE_REGULAR = 2;
+  TITLE_STYLE_SMALL = 3;
 }
 
 /**
@@ -695,14 +716,20 @@ message Row {
    */
   optional FollowUp follow_up = 9;
 
-  /** Control the style of the title on row level */
-  optional Collection.HeadingStyle heading_style = 10;
+  /** Deprecated.  It was the old heading style. */
+  reserved "heading_style";
+  reserved 10;
 
   /**
    * The property gives the ID for tracking data which is sent by
    * the apps when users tap the row title.
    */
   optional string tracking_id = 11;
+
+  /**
+   * Control in what style to display the row title.
+   */
+  optional TitleStyle title_style = 12;
 }
 
 message Topic {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -85,6 +85,26 @@
             ]
           },
           {
+            "name": "TitleStyle",
+            "enum_fields": [
+              {
+                "name": "TITLE_STYLE_UNSPECIFIED"
+              },
+              {
+                "name": "TITLE_STYLE_HIDDEN",
+                "integer": 1
+              },
+              {
+                "name": "TITLE_STYLE_REGULAR",
+                "integer": 2
+              },
+              {
+                "name": "TITLE_STYLE_SMALL",
+                "integer": 3
+              }
+            ]
+          },
+          {
             "name": "Card.CardType",
             "enum_fields": [
               {
@@ -489,6 +509,12 @@
                 "id": 21,
                 "name": "last_updated_date",
                 "type": "google.protobuf.Timestamp",
+                "optional": true
+              },
+              {
+                "id": 22,
+                "name": "title_style",
+                "type": "TitleStyle",
                 "optional": true
               }
             ]
@@ -1563,17 +1589,23 @@
                 "optional": true
               },
               {
-                "id": 10,
-                "name": "heading_style",
-                "type": "Collection.HeadingStyle",
-                "optional": true
-              },
-              {
                 "id": 11,
                 "name": "tracking_id",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 12,
+                "name": "title_style",
+                "type": "TitleStyle",
+                "optional": true
               }
+            ],
+            "reserved_ids": [
+              10
+            ],
+            "reserved_names": [
+              "heading_style"
             ]
           },
           {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We defined `HeadingStyle` enum type and added a `heading_style` property both in `Collection` message in #109 to support the regular and small style of title.

Later on, we needed to add a similar property to the `Row` message and referenced the `HeadingStyle` enum in `Collection` message in #119 to enable code sharing.

After discussion with native devs, we agreed that it was more sensible and manageable to decouple the `HeadingStyle` enum definition from `Collection` message.

Therefore, this pull request defines the enum type in top level and renames it to `TitleStyle` to avoid confusion.  A property named `title_style` referencing this new enum type is added to `Collection` and `Row`.

We are going to keep the `heading_style` in Collection for a while because it has been accessed by production apps.  The `heading_style` in Row has not been used so we remove the field and just reserve its field name and field number so that nobody would use it accidentally in future.
