### PR TITLE
[Fairground] Add image aspect ratio to Collection

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -132,6 +132,11 @@ message Collection {
    * Control in what style to display the collection title.
    */
   optional TitleStyle title_style = 22;
+
+  /**
+   * The default aspect ratio for trail images in this collection.
+   */
+  optional ImageAspectRatio preferred_image_aspect_ratio = 23;
 }
 
 /**
@@ -557,22 +562,14 @@ message Card {
   optional int32 trail_image_size = 39 [deprecated = true];
 
   /**
-   * Define constants for each image aspect ratio supported
+   * Deprecated field.  It was the aspect ratio for trail image but
+   * it was no longer needed because the card size can imply the image
+   * aspect ratio needed.  When a card size can support a new image
+   * aspect ratio and the old 5:3 crop, the native can check
+   * the preferred_image_aspect_ratio property in the collection.
    */
-  enum ImageAspectRatio {
-    IMAGE_ASPECT_RATIO_UNSPECIFIED = 0;
-    IMAGE_ASPECT_RATIO_LANDSCAPE_5_3 = 1;
-    IMAGE_ASPECT_RATIO_LANDSCAPE_5_4 = 2;
-    IMAGE_ASPECT_RATIO_PORTRAIT_4_5 = 3;
-    IMAGE_ASPECT_RATIO_SQUARE = 4;
-  }
-
-  /**
-   * Indicate in what aspect ratio the trail image should be rendered.
-   * It is deprecated as the image aspect ratio is implied by
-   * the card size.
-   */
-  optional ImageAspectRatio trail_image_aspect_ratio = 40 [deprecated = true];
+  reserved 40;
+  reserved "trail_image_aspect_ratio";
 
   /**
    * Define constants for the arrangement of sublinks on a card
@@ -659,6 +656,17 @@ enum TopBorderStyle {
   TOP_BORDER_STYLE_UNSPECIFIED = 0;
   TOP_BORDER_STYLE_HIDDEN = 1;
   TOP_BORDER_STYLE_REGULAR = 2;
+}
+
+/**
+  * Define constants for each image aspect ratio supported
+  */
+enum ImageAspectRatio {
+  IMAGE_ASPECT_RATIO_UNSPECIFIED = 0;
+  IMAGE_ASPECT_RATIO_LANDSCAPE_5_3 = 1;
+  IMAGE_ASPECT_RATIO_LANDSCAPE_5_4 = 2;
+  IMAGE_ASPECT_RATIO_PORTRAIT_4_5 = 3;
+  IMAGE_ASPECT_RATIO_SQUARE = 4;
 }
 
 message Column {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -153,30 +153,6 @@
             ]
           },
           {
-            "name": "Card.ImageAspectRatio",
-            "enum_fields": [
-              {
-                "name": "IMAGE_ASPECT_RATIO_UNSPECIFIED"
-              },
-              {
-                "name": "IMAGE_ASPECT_RATIO_LANDSCAPE_5_3",
-                "integer": 1
-              },
-              {
-                "name": "IMAGE_ASPECT_RATIO_LANDSCAPE_5_4",
-                "integer": 2
-              },
-              {
-                "name": "IMAGE_ASPECT_RATIO_PORTRAIT_4_5",
-                "integer": 3
-              },
-              {
-                "name": "IMAGE_ASPECT_RATIO_SQUARE",
-                "integer": 4
-              }
-            ]
-          },
-          {
             "name": "Card.SublinksArrangement",
             "enum_fields": [
               {
@@ -289,6 +265,30 @@
               {
                 "name": "TOP_BORDER_STYLE_REGULAR",
                 "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "ImageAspectRatio",
+            "enum_fields": [
+              {
+                "name": "IMAGE_ASPECT_RATIO_UNSPECIFIED"
+              },
+              {
+                "name": "IMAGE_ASPECT_RATIO_LANDSCAPE_5_3",
+                "integer": 1
+              },
+              {
+                "name": "IMAGE_ASPECT_RATIO_LANDSCAPE_5_4",
+                "integer": 2
+              },
+              {
+                "name": "IMAGE_ASPECT_RATIO_PORTRAIT_4_5",
+                "integer": 3
+              },
+              {
+                "name": "IMAGE_ASPECT_RATIO_SQUARE",
+                "integer": 4
               }
             ]
           },
@@ -515,6 +515,12 @@
                 "id": 22,
                 "name": "title_style",
                 "type": "TitleStyle",
+                "optional": true
+              },
+              {
+                "id": 23,
+                "name": "preferred_image_aspect_ratio",
+                "type": "ImageAspectRatio",
                 "optional": true
               }
             ]
@@ -1432,18 +1438,6 @@
                 ]
               },
               {
-                "id": 40,
-                "name": "trail_image_aspect_ratio",
-                "type": "ImageAspectRatio",
-                "optional": true,
-                "options": [
-                  {
-                    "name": "deprecated",
-                    "value": "true"
-                  }
-                ]
-              },
-              {
                 "id": 41,
                 "name": "sublinks_arrangement",
                 "type": "SublinksArrangement",
@@ -1503,6 +1497,12 @@
                 "type": "TopBorderStyle",
                 "optional": true
               }
+            ],
+            "reserved_ids": [
+              40
+            ],
+            "reserved_names": [
+              "trail_image_aspect_ratio"
             ]
           },
           {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are introducing new image crops to be displayed on fronts as part of the homepage redesign project.

In most cases, the card size in the `Card` message implies the desired aspect ratio for the trail image on the card.  However, some card sizes already existed when the new aspect ratio was introduced, and we want them to show the existing 5:3 landscape crop on old collection types while showing the new 5:4 landscape crop on new types.

Therefore, we raise this pull request to add a new property `preferred_image_aspect_ratio` in the `Collection` message to indicate what image aspect ratio is preferred for this collection.

In long term, MAPI should pull the preferred image aspect ratio through from the front config tool. 