### PR TITLE
[Fairground] Add a property on the font weight of the headline on Cards

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -650,6 +650,11 @@ message Card {
    * Control how the top border is displayed.
    */
   optional TopBorderStyle top_border_style = 47;
+
+  /**
+   * Control what font weight to use for the headline.
+   */
+  optional FontWeight headline_weight = 48;
 }
 
 enum TopBorderStyle {
@@ -667,6 +672,15 @@ enum ImageAspectRatio {
   IMAGE_ASPECT_RATIO_LANDSCAPE_5_4 = 2;
   IMAGE_ASPECT_RATIO_PORTRAIT_4_5 = 3;
   IMAGE_ASPECT_RATIO_SQUARE = 4;
+}
+
+/**
+  * Define different levels for font weight
+  */
+enum FontWeight {
+  FONT_WEIGHT_UNSPECIFIED = 0;
+  FONT_WEIGHT_STANDARD = 1;
+  FONT_WEIGHT_LIGHT = 2;
 }
 
 message Column {
@@ -699,8 +713,21 @@ message Row {
     ROW_TYPE_PROGRAMMATIC_CAROUSEL = 4;
   }
   repeated Column columns = 1;
-  optional Palette palette_light = 2;
-  optional Palette palette_dark = 3;
+
+  /**
+   * Deprecate the palette_light property in a Row as we did
+   * not and will not use this property.
+   */
+  reserved "palette_light";
+  reserved 2;
+
+  /**
+   * Deprecate the palette_dark property in a Row as we did
+   * not and will not use this property.
+   */
+  reserved "palette_dark";
+  reserved 3;
+
   /**
    * Tablet devices support a 4 column display, whereas mobile devices
    * support a 2 column display. If a mobile device receives a row with a

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -293,6 +293,22 @@
             ]
           },
           {
+            "name": "FontWeight",
+            "enum_fields": [
+              {
+                "name": "FONT_WEIGHT_UNSPECIFIED"
+              },
+              {
+                "name": "FONT_WEIGHT_STANDARD",
+                "integer": 1
+              },
+              {
+                "name": "FONT_WEIGHT_LIGHT",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "Row.RowType",
             "enum_fields": [
               {
@@ -1502,6 +1518,12 @@
                 "name": "top_border_style",
                 "type": "TopBorderStyle",
                 "optional": true
+              },
+              {
+                "id": 48,
+                "name": "headline_weight",
+                "type": "FontWeight",
+                "optional": true
               }
             ],
             "reserved_ids": [
@@ -1547,18 +1569,6 @@
                 "name": "columns",
                 "type": "Column",
                 "is_repeated": true
-              },
-              {
-                "id": 2,
-                "name": "palette_light",
-                "type": "Palette",
-                "optional": true
-              },
-              {
-                "id": 3,
-                "name": "palette_dark",
-                "type": "Palette",
-                "optional": true
               },
               {
                 "id": 4,
@@ -1608,9 +1618,13 @@
               }
             ],
             "reserved_ids": [
+              2,
+              3,
               10
             ],
             "reserved_names": [
+              "palette_light",
+              "palette_dark",
               "heading_style"
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are building opinion cards as part of Fairground project.  Opinion cards have a lighter font weight in their headlines on the new design.

The pull request defines a new enum type for font weight and add a new property `headline_weight` to control the font weight of the headline of a card. 

It also deprecates the `palette_light` and `palette_dark` properties in `Row` as we did not use these two properties at all.