### PR TITLE
Add latest episode field

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -337,6 +337,7 @@ message PodcastSeries {
   optional FollowUp follow_up = 4;
   optional Image image = 5;
   optional string description = 6;
+  optional string lastest_episode = 7;
 }
 
 // This message is only applicable to live blogs.

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -337,7 +337,7 @@ message PodcastSeries {
   optional FollowUp follow_up = 4;
   optional Image image = 5;
   optional string description = 6;
-  optional string latest_episode = 7;
+  optional Audio latest_episode = 7;
 }
 
 // This message is only applicable to live blogs.

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -337,7 +337,7 @@ message PodcastSeries {
   optional FollowUp follow_up = 4;
   optional Image image = 5;
   optional string description = 6;
-  optional string lastest_episode = 7;
+  optional string latest_episode = 7;
 }
 
 // This message is only applicable to live blogs.

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1009,7 +1009,7 @@
               },
               {
                 "id": 7,
-                "name": "lastest_episode",
+                "name": "latest_episode",
                 "type": "string",
                 "optional": true
               }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1010,7 +1010,7 @@
               {
                 "id": 7,
                 "name": "latest_episode",
-                "type": "string",
+                "type": "Audio",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1006,6 +1006,12 @@
                 "name": "description",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 7,
+                "name": "lastest_episode",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a `latestEpisode` attribute to the `PodcastSeries` field so that we can add a playable button for the latest episode for cards of `PODCAST_SERIES_CARD`

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
