### PR TITLE
Add fields for football team and tables

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -838,3 +838,155 @@ message BasicTag {
   string id = 1;
   string web_title = 2;
 }
+
+/************************* FOOTBALL *************************/
+
+
+// The following messages are used to model the contents for our
+// blueprint football endpoints. Currently a WIP and not in prod/beta.
+
+/**
+ * A football team
+ */
+message Team {
+  /**
+   * Each team will have a unique numerical ID
+   */
+  string id = 1;
+
+  /**
+   * The name of the team, i.e "Luton Town"
+   */
+  string name = 2;
+
+  /**
+   * The short code name for the team, i.e "LUT"
+   */
+  string short_code = 3;
+
+  /**
+   * The team's crest or flag for countries
+   */
+  Image crest = 4;
+}
+
+/**
+ * Some leagues can have multiple tables, i.e group stage tables
+ */
+ message TableGroups {
+
+  /**
+   * The name of the competition, i.e "UEFA Nations League"
+   */
+  string competition_name = 1;
+
+  /**
+   * The table (or tables) for that league.
+   */
+  repeated Table tables = 2;
+}
+
+/**
+ * A football table for either a competition or league.
+ * One competition/league may be composed of many tables 
+ * in the case of those with groups. E.g., world cups 
+ * have group stages. 
+ */
+message Table {
+  /**
+   * The group name, for example "Group A". Only useful
+    * for competitions with groups.
+   */
+  optional string group_name = 1;
+
+  /**
+   * Each team and their position in the table
+   */
+  repeated TablePosition teams = 2;
+}
+
+/**
+ * A team, their position within a league and other stats,
+ * i.e Luton Town at 2nd place with n goal difference etc.
+ */
+message TablePosition {
+
+  /**
+   * A football team
+   */
+  Team team = 1;
+
+  /**
+   * The team's position in the table, i.e 2 for 2nd place
+   */
+  int32 position = 2;
+
+  /**
+   * The number of games played
+   */
+  int32 played = 3;
+
+  /**
+   * The number of games won
+   */
+  int32 won = 4;
+
+  /**
+   * The number of games drawn
+   */
+  int32 drawn = 5;
+
+  /**
+   * The number of games lost
+   */
+  int32 lost = 6;
+
+  /**
+   * The number of goals scored
+   */
+  int32 goals_for = 7;
+
+  /**
+   * The number of goals conceded
+   */
+  int32 goals_against = 8;
+
+  /**
+   * The goal difference
+   */
+  int32 goal_difference = 9;
+
+  /**
+   * The number of points
+   */
+  int32 points = 10;
+  
+  /**
+   * The recent form of the team
+   *
+   */
+   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
+  repeated Form recent_form = 11;
+  
+  /**
+   * Whether to show a divider after this team in the table
+   * to illustrate the relegation/promotion line
+   */
+  bool show_divider = 12;
+
+  /**
+   * Tells you if a previous game was won, drawn or lost
+   */
+  enum Form {
+    FORM_UNSPECIFIED = 0;
+    FORM_WIN = 1;
+    FORM_DRAW = 2;
+    FORM_LOSS = 3;
+  }
+
+  /** 
+   * The in-app follow-up if the team is clicked.
+   * This will be used to navigate to the tag page for that team
+   */
+  optional FollowUp follow_up = 13;
+}

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -873,7 +873,7 @@ message Team {
 /**
  * Some leagues can have multiple tables, i.e group stage tables
  */
- message TableGroups {
+message TableGroups {
 
   /**
    * The name of the competition, i.e "UEFA Nations League"
@@ -965,7 +965,7 @@ message TablePosition {
    * The recent form of the team
    *
    */
-   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
+  // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   repeated Form recent_form = 11;
   
   /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -395,6 +395,26 @@
                 "integer": 13
               }
             ]
+          },
+          {
+            "name": "TablePosition.Form",
+            "enum_fields": [
+              {
+                "name": "FORM_UNSPECIFIED"
+              },
+              {
+                "name": "FORM_WIN",
+                "integer": 1
+              },
+              {
+                "name": "FORM_DRAW",
+                "integer": 2
+              },
+              {
+                "name": "FORM_LOSS",
+                "integer": 3
+              }
+            ]
           }
         ],
         "messages": [
@@ -1776,6 +1796,135 @@
                 "id": 2,
                 "name": "web_title",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Team",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "short_code",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "crest",
+                "type": "Image"
+              }
+            ]
+          },
+          {
+            "name": "Table",
+            "fields": [
+              {
+                "id": 1,
+                "name": "group_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "teams",
+                "type": "TablePosition",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TableGroups",
+            "fields": [
+              {
+                "id": 1,
+                "name": "competition_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "tables",
+                "type": "Table",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TablePosition",
+            "fields": [
+              {
+                "id": 1,
+                "name": "team",
+                "type": "Team"
+              },
+              {
+                "id": 2,
+                "name": "position",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "played",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "won",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "drawn",
+                "type": "int32"
+              },
+              {
+                "id": 6,
+                "name": "lost",
+                "type": "int32"
+              },
+              {
+                "id": 7,
+                "name": "goals_for",
+                "type": "int32"
+              },
+              {
+                "id": 8,
+                "name": "goals_against",
+                "type": "int32"
+              },
+              {
+                "id": 9,
+                "name": "goal_difference",
+                "type": "int32"
+              },
+              {
+                "id": 10,
+                "name": "points",
+                "type": "int32"
+              },
+              {
+                "id": 11,
+                "name": "recent_form",
+                "type": "Form",
+                "is_repeated": true
+              },
+              {
+                "id": 12,
+                "name": "show_divider",
+                "type": "bool"
+              },
+              {
+                "id": 13,
+                "name": "follow_up",
+                "type": "FollowUp",
+                "optional": true
               }
             ]
           }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds models so that we can return the football tables in blueprint. Please see [this corresponding MAPI PR](https://github.com/guardian/mobile-apps-api/pull/3363).

