### PR TITLE
Create models for blueprint football matches

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -1054,11 +1054,6 @@ message Match {
   optional string match_detail = 6;
 
   /**
-   * Whether the match is live or not
-   */
-  bool is_live = 7;
-
-  /**
    * The URL to retrieve the match report (if it exists),
    * stats and topic for notification.
    */

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -962,11 +962,11 @@ message TablePosition {
    */
   int32 points = 10;
   
+  // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   /**
    * The recent form of the team
    *
    */
-  // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   repeated Form recent_form = 11;
   
   /**

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -990,3 +990,76 @@ message TablePosition {
    */
   optional FollowUp follow_up = 13;
 }
+
+/**
+ * Each results/fixtures response will contain a list of match
+ * days for the chosen league. Fixtures will be returned in 
+  * chronological order and matches in reverse chronological order.
+ */
+message CompetitionWithMatchDays {
+
+  /**
+   * The match days for the league
+   */
+  repeated MatchDay match_days = 1;
+
+  /**
+   * The name of the competition, i.e "Premier League"
+   */
+  string competition_name = 2;
+}
+
+message MatchDay {
+
+  /**
+   * The date of the match day. Will be the start of the day.
+   */
+  google.protobuf.Timestamp date = 1;
+
+  /**
+   * i.e "Premier League" or if live "Premier League live"
+   */
+  string match_day_name = 3;
+
+  /**
+   * The matches for the competition on the date
+   */
+  repeated Match matches = 2;
+
+  /**
+   * Whether or not there are live matches happening and
+   * whether to show the live dot. 
+   */
+  bool is_live = 4;
+}
+
+message Match {
+  
+  string id = 1;
+  Team home_team = 2;
+  Team away_team = 3;
+  google.protobuf.Timestamp kick_off = 4;
+
+  /** 
+   * The score of the match, i.e "2-1". Optional as the match may not 
+   * have started yet.
+   */
+  optional string score = 5;
+
+  /** 
+   * Could be the status of the match, i.e "FT" for full time
+   or an aggregate score, i.e "2-1" for a two legged match.
+   */
+  optional string match_detail = 6;
+
+  /**
+   * Whether the match is live or not
+   */
+  bool is_live = 7;
+
+  /**
+   * The URL to retrieve the match report (if it exists),
+   * stats and topic for notification.
+   */
+  optional string match_info_uri = 9;
+}

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -1026,12 +1026,6 @@ message MatchDay {
    * The matches for the competition on the date
    */
   repeated Match matches = 2;
-
-  /**
-   * Whether or not there are live matches happening and
-   * whether to show the live dot. 
-   */
-  bool is_live = 4;
 }
 
 message Match {
@@ -1057,5 +1051,5 @@ message Match {
    * The URL to retrieve the match report (if it exists),
    * stats and topic for notification.
    */
-  optional string match_info_uri = 9;
+  optional string match_info_uri = 7;
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1825,22 +1825,6 @@
             ]
           },
           {
-            "name": "Table",
-            "fields": [
-              {
-                "id": 1,
-                "name": "group_name",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "teams",
-                "type": "TablePosition",
-                "is_repeated": true
-              }
-            ]
-          },
-          {
             "name": "TableGroups",
             "fields": [
               {
@@ -1852,6 +1836,23 @@
                 "id": 2,
                 "name": "tables",
                 "type": "Table",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Table",
+            "fields": [
+              {
+                "id": 1,
+                "name": "group_name",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "teams",
+                "type": "TablePosition",
                 "is_repeated": true
               }
             ]
@@ -1924,6 +1925,96 @@
                 "id": 13,
                 "name": "follow_up",
                 "type": "FollowUp",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "CompetitionWithMatchDays",
+            "fields": [
+              {
+                "id": 1,
+                "name": "match_days",
+                "type": "MatchDay",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "competition_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MatchDay",
+            "fields": [
+              {
+                "id": 1,
+                "name": "date",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 3,
+                "name": "match_day_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "matches",
+                "type": "Match",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "is_live",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Match",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "home_team",
+                "type": "Team"
+              },
+              {
+                "id": 3,
+                "name": "away_team",
+                "type": "Team"
+              },
+              {
+                "id": 4,
+                "name": "kick_off",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 5,
+                "name": "score",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "match_detail",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "is_live",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "match_info_uri",
+                "type": "string",
                 "optional": true
               }
             ]

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -2013,11 +2013,6 @@
                 "optional": true
               },
               {
-                "id": 7,
-                "name": "is_live",
-                "type": "bool"
-              },
-              {
                 "id": 9,
                 "name": "match_info_uri",
                 "type": "string",

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1969,11 +1969,6 @@
                 "name": "matches",
                 "type": "Match",
                 "is_repeated": true
-              },
-              {
-                "id": 4,
-                "name": "is_live",
-                "type": "bool"
               }
             ]
           },
@@ -2013,7 +2008,7 @@
                 "optional": true
               },
               {
-                "id": 9,
+                "id": 7,
                 "name": "match_info_uri",
                 "type": "string",
                 "optional": true


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds models so that we can return football matches in blueprint. Please see [this corresponding MAPI PR](https://github.com/guardian/mobile-apps-api/pull/3380).
