### PR TITLE
Add `VerticalSpacing` property to `Collection`s

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -137,6 +137,18 @@ message Collection {
    * The default aspect ratio for trail images in this collection.
    */
   optional ImageAspectRatio preferred_image_aspect_ratio = 23;
+  
+  /**
+   * Vertical spacing between contents of the collection. This will apply to
+   * spacing between rows, and spacing between cards in a column.
+   */
+  optional VerticalSpacing content_vertical_spacing = 24;
+}
+
+enum VerticalSpacing {
+  VERTICAL_SPACING_UNSPECIFIED = 0;
+  VERTICAL_SPACING_REGULAR = 1;
+  VERTICAL_SPACING_COMPACT = 2;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -45,6 +45,22 @@
             ]
           },
           {
+            "name": "VerticalSpacing",
+            "enum_fields": [
+              {
+                "name": "VERTICAL_SPACING_UNSPECIFIED"
+              },
+              {
+                "name": "VERTICAL_SPACING_REGULAR",
+                "integer": 1
+              },
+              {
+                "name": "VERTICAL_SPACING_COMPACT",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "FollowUp.FollowUpType",
             "enum_fields": [
               {
@@ -561,6 +577,12 @@
                 "id": 23,
                 "name": "preferred_image_aspect_ratio",
                 "type": "ImageAspectRatio",
+                "optional": true
+              },
+              {
+                "id": 24,
+                "name": "content_vertical_spacing",
+                "type": "VerticalSpacing",
                 "optional": true
               }
             ]
@@ -1831,22 +1853,6 @@
             ]
           },
           {
-            "name": "Table",
-            "fields": [
-              {
-                "id": 1,
-                "name": "group_name",
-                "type": "string"
-              },
-              {
-                "id": 2,
-                "name": "teams",
-                "type": "TablePosition",
-                "is_repeated": true
-              }
-            ]
-          },
-          {
             "name": "TableGroups",
             "fields": [
               {
@@ -1858,6 +1864,23 @@
                 "id": 2,
                 "name": "tables",
                 "type": "Table",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Table",
+            "fields": [
+              {
+                "id": 1,
+                "name": "group_name",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "teams",
+                "type": "TablePosition",
                 "is_repeated": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Created a new enum `VerticalSpacing` with values `Regular` and `Compact`.
* Added a new property `content_vertical_spacing` to `Collection` model.

The intent of this PR is that MAPI will guide the apps on which vertical spacing to use for rows & cards within a collection. 
* This will default to `Regular` for most collections (represented as 24px in-app)
* For all MyGuardian and some Podcast tab collections, we'll use `Compact` (represented as 16px in-app)

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

