### PR TITLE
Revert version.sbt to 1.0.40-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.40"
+ThisBuild / version := "1.0.40-SNAPSHOT"


### PR DESCRIPTION
Our automated release workflow failed partway through because of an expired key which has [since been rectified](https://github.com/guardian/gha-scala-library-release-workflow/pull/48). However, the workflow did succeed far enough to make [this commit](https://github.com/guardian/mobile-apps-api-models/commit/1cbb85b3396c96ee825de187724e5860a9ec1b22) which removes the snapshot suffix. Subsequently, when I tried to run the release again, it [failed](https://github.com/guardian/mobile-apps-api-models/actions/runs/12167136195) as it was expecting the "snapshot" suffix. This PR essentially reverts that commit so we can give the release another go.