### PR TITLE
[Fairground] Add properties to control visibility of dividers on row level

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -699,6 +699,12 @@ message Column {
   optional Palette palette_dark = 3;
   // The card(s) in the column assume this preferred width.
   int32 preferred_width = 4;
+
+  /**
+   * Decide whether to show horizontal dividers between cards which
+   * are stacked in this column.
+   */
+  optional bool show_horizontal_dividers = 5;
 }
 
 message Row {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -771,6 +771,17 @@ message Row {
    * Control in what style to display the row title.
    */
   optional TitleStyle title_style = 12;
+
+  /**
+   * Decide whether to show vertical dividers in between cards on
+   * this row
+   */
+  optional bool show_vertical_dividers = 13;
+
+  /**
+   * Decide whether to show horizontal dividers at the top of this row
+   */
+  optional bool show_horizontal_dividers = 14;
 }
 
 message Topic {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1594,6 +1594,12 @@
                 "id": 4,
                 "name": "preferred_width",
                 "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "show_horizontal_dividers",
+                "type": "bool",
+                "optional": true
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1651,6 +1651,18 @@
                 "name": "title_style",
                 "type": "TitleStyle",
                 "optional": true
+              },
+              {
+                "id": 13,
+                "name": "show_vertical_dividers",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "show_horizontal_dividers",
+                "type": "bool",
+                "optional": true
               }
             ],
             "reserved_ids": [


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fairground designs include vertical dividing lines, as well in some cases horizontal dividers that span beyond one card.

In order to support the continuous card dividers, as well as try to simplify our logic around card dividers both on the client and in MAPI we agreed with design that we could move towards row based dividers which live outside of cards.

This pull request adds a new property `show_vertical_dividers` and `show_horizontal_dividers` to `Row` to control the visibility of vertical dividing lines between cards and horizontal dividing lines at the top of the row respectively.

In addition, it adds a similar property `show_horizontal_dividers` to `Column` for the horizontal dividing lines in between the cards stacked in the column.
