### PR TITLE
[Fairground] Add palette colours for the pill on media cards

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -283,6 +283,16 @@ message Palette {
    * colour.
    */
   string kicker_text = 16;
+
+  /*
+  * The background colour of the pill on media cards.
+  */
+  string media_pill_background = 17;
+
+  /*
+  * The foreground colour of the pill on media cards.
+  */
+  string media_pill_foreground = 18;
 }
 
 message Links {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -838,6 +838,16 @@
                 "id": 16,
                 "name": "kicker_text",
                 "type": "string"
+              },
+              {
+                "id": 17,
+                "name": "media_pill_background",
+                "type": "string"
+              },
+              {
+                "id": 18,
+                "name": "media_pill_foreground",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are building new media cards as part of the homepage redesign project.  On the new design, there is a pill component on the card to show, for example, the number of images for a gallery or the duration of the video.

<img width="640px" src="https://github.com/user-attachments/assets/eeadc55e-f380-4755-b96a-c1acdd49778b" />

The pull request adds new properties `media_pill_background` and `meida_pill_foreground` to `Palette` to provide the native apps with the colours to use on the pill component.