### PR TITLE
Add fields for tag list page

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -231,6 +231,7 @@ message Header {
 }
 
 enum HeaderType {
+  HEADER_TYPE_UNSPECIFIED = 0;
   HEADER_TYPE_CENTRE = 1;
   HEADER_TYPE_DEFAULT = 2;
 }

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -214,8 +214,26 @@ message List {
   string ad_unit = 16;
 
   optional google.protobuf.Timestamp last_updated_date = 17;
+
+  optional Header header = 18;
 }
 
+
+message Header {
+  string header_text = 0;
+  optional MyGuardianFollow my_guardian_follow = 1;
+  optional string description = 2;
+  AlignmentType alignment = 3;
+  optional Branding branding = 4;
+  optional Palette palette_light = 5;
+  optional Palette palette_dark = 6;
+  optional Image image = 7;
+}
+
+enum HeaderType {
+  HEADER_TYPE_CENTRE = 0;
+  HEADER_TYPE_LEFT = 1;
+}
 /************************* MY GUARDIAN *************************/
 
 // The following messages are used only to model the contents of our

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -221,13 +221,11 @@ message List {
 
 message Header {
   string header_text = 1;
-  optional MyGuardianFollow my_guardian_follow = 2;
-  optional string description = 3;
-  HeaderType alignment = 4;
-  optional Branding branding = 5;
-  optional Palette palette_light = 6;
-  optional Palette palette_dark = 7;
-  optional Image image = 8;
+  optional string description = 2;
+  HeaderType alignment = 3;
+  optional Palette palette_light = 4;
+  optional Palette palette_dark = 5;
+  optional Image image = 6;
 }
 
 enum HeaderType {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -220,19 +220,19 @@ message List {
 
 
 message Header {
-  string header_text = 0;
-  optional MyGuardianFollow my_guardian_follow = 1;
-  optional string description = 2;
-  AlignmentType alignment = 3;
-  optional Branding branding = 4;
-  optional Palette palette_light = 5;
-  optional Palette palette_dark = 6;
-  optional Image image = 7;
+  string header_text = 1;
+  optional MyGuardianFollow my_guardian_follow = 2;
+  optional string description = 3;
+  HeaderType alignment = 4;
+  optional Branding branding = 5;
+  optional Palette palette_light = 6;
+  optional Palette palette_dark = 7;
+  optional Image image = 8;
 }
 
 enum HeaderType {
   HEADER_TYPE_CENTRE = 0;
-  HEADER_TYPE_LEFT = 1;
+  HEADER_TYPE_DEFAULT = 1;
 }
 /************************* MY GUARDIAN *************************/
 
@@ -924,9 +924,9 @@ message TableGroups {
 
 /**
  * A football table for either a competition or league.
- * One competition/league may be composed of many tables 
- * in the case of those with groups. E.g., world cups 
- * have group stages. 
+ * One competition/league may be composed of many tables
+ * in the case of those with groups. E.g., world cups
+ * have group stages.
  */
 message Table {
   /**
@@ -996,14 +996,14 @@ message TablePosition {
    * The number of points
    */
   int32 points = 10;
-  
+
   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   /**
    * The recent form of the team
    *
    */
   repeated Form recent_form = 11;
-  
+
   /**
    * Whether to show a divider after this team in the table
    * to illustrate the relegation/promotion line
@@ -1020,7 +1020,7 @@ message TablePosition {
     FORM_LOSS = 3;
   }
 
-  /** 
+  /**
    * The in-app follow-up if the team is clicked.
    * This will be used to navigate to the tag page for that team
    */
@@ -1029,7 +1029,7 @@ message TablePosition {
 
 /**
  * Each results/fixtures response will contain a list of match
- * days for the chosen league. Fixtures will be returned in 
+ * days for the chosen league. Fixtures will be returned in
   * chronological order and matches in reverse chronological order.
  */
 message CompetitionWithMatchDays {
@@ -1064,19 +1064,19 @@ message MatchDay {
 }
 
 message Match {
-  
+
   string id = 1;
   Team home_team = 2;
   Team away_team = 3;
   google.protobuf.Timestamp kick_off = 4;
 
-  /** 
-   * The score of the match, i.e "2-1". Optional as the match may not 
+  /**
+   * The score of the match, i.e "2-1". Optional as the match may not
    * have started yet.
    */
   optional string score = 5;
 
-  /** 
+  /**
    * Could be the status of the match, i.e "FT" for full time
    or an aggregate score, i.e "2-1" for a two legged match.
    */

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -231,8 +231,8 @@ message Header {
 }
 
 enum HeaderType {
-  HEADER_TYPE_CENTRE = 0;
-  HEADER_TYPE_DEFAULT = 1;
+  HEADER_TYPE_CENTRE = 1;
+  HEADER_TYPE_DEFAULT = 2;
 }
 /************************* MY GUARDIAN *************************/
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -736,41 +736,29 @@
               },
               {
                 "id": 2,
-                "name": "my_guardian_follow",
-                "type": "MyGuardianFollow",
-                "optional": true
-              },
-              {
-                "id": 3,
                 "name": "description",
                 "type": "string",
                 "optional": true
               },
               {
-                "id": 4,
+                "id": 3,
                 "name": "alignment",
                 "type": "HeaderType"
               },
               {
-                "id": 5,
-                "name": "branding",
-                "type": "Branding",
-                "optional": true
-              },
-              {
-                "id": 6,
+                "id": 4,
                 "name": "palette_light",
                 "type": "Palette",
                 "optional": true
               },
               {
-                "id": 7,
+                "id": 5,
                 "name": "palette_dark",
                 "type": "Palette",
                 "optional": true
               },
               {
-                "id": 8,
+                "id": 6,
                 "name": "image",
                 "type": "Image",
                 "optional": true

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -68,6 +68,9 @@
             "name": "HeaderType",
             "enum_fields": [
               {
+                "name": "HEADER_TYPE_UNSPECIFIED"
+              },
+              {
                 "name": "HEADER_TYPE_CENTRE",
                 "integer": 1
               },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -68,11 +68,12 @@
             "name": "HeaderType",
             "enum_fields": [
               {
-                "name": "HEADER_TYPE_CENTRE"
+                "name": "HEADER_TYPE_CENTRE",
+                "integer": 1
               },
               {
                 "name": "HEADER_TYPE_DEFAULT",
-                "integer": 1
+                "integer": 2
               }
             ]
           },

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -71,7 +71,7 @@
                 "name": "HEADER_TYPE_CENTRE"
               },
               {
-                "name": "HEADER_TYPE_LEFT",
+                "name": "HEADER_TYPE_DEFAULT",
                 "integer": 1
               }
             ]
@@ -726,46 +726,47 @@
             "name": "Header",
             "fields": [
               {
+                "id": 1,
                 "name": "header_text",
                 "type": "string"
               },
               {
-                "id": 1,
+                "id": 2,
                 "name": "my_guardian_follow",
                 "type": "MyGuardianFollow",
                 "optional": true
               },
               {
-                "id": 2,
+                "id": 3,
                 "name": "description",
                 "type": "string",
                 "optional": true
               },
               {
-                "id": 3,
+                "id": 4,
                 "name": "alignment",
-                "type": "AlignmentType"
+                "type": "HeaderType"
               },
               {
-                "id": 4,
+                "id": 5,
                 "name": "branding",
                 "type": "Branding",
                 "optional": true
               },
               {
-                "id": 5,
+                "id": 6,
                 "name": "palette_light",
                 "type": "Palette",
                 "optional": true
               },
               {
-                "id": 6,
+                "id": 7,
                 "name": "palette_dark",
                 "type": "Palette",
                 "optional": true
               },
               {
-                "id": 7,
+                "id": 8,
                 "name": "image",
                 "type": "Image",
                 "optional": true

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -65,6 +65,18 @@
             ]
           },
           {
+            "name": "HeaderType",
+            "enum_fields": [
+              {
+                "name": "HEADER_TYPE_CENTRE"
+              },
+              {
+                "name": "HEADER_TYPE_LEFT",
+                "integer": 1
+              }
+            ]
+          },
+          {
             "name": "MediaType",
             "enum_fields": [
               {
@@ -700,6 +712,62 @@
                 "id": 17,
                 "name": "last_updated_date",
                 "type": "google.protobuf.Timestamp",
+                "optional": true
+              },
+              {
+                "id": 18,
+                "name": "header",
+                "type": "Header",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "Header",
+            "fields": [
+              {
+                "name": "header_text",
+                "type": "string"
+              },
+              {
+                "id": 1,
+                "name": "my_guardian_follow",
+                "type": "MyGuardianFollow",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "description",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "alignment",
+                "type": "AlignmentType"
+              },
+              {
+                "id": 4,
+                "name": "branding",
+                "type": "Branding",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "palette_light",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "palette_dark",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "image",
+                "type": "Image",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a `HEADER` object that will be used in the List endpoint in order to present the new tag page 

![new-tag-page](https://github.com/user-attachments/assets/4804a3fe-78d6-407b-af61-8ca31fd6436b)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
