### PR TITLE
Remove the header type default

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -231,7 +231,6 @@ message Header {
 enum HeaderType {
   HEADER_TYPE_UNSPECIFIED = 0;
   HEADER_TYPE_CENTRE = 1;
-  HEADER_TYPE_DEFAULT = 2;
 }
 /************************* MY GUARDIAN *************************/
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -73,10 +73,6 @@
               {
                 "name": "HEADER_TYPE_CENTRE",
                 "integer": 1
-              },
-              {
-                "name": "HEADER_TYPE_DEFAULT",
-                "integer": 2
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

It was found that the name `default` conflicted with a keyword in swift. We are only using the `centre` enum for now, so this removes the unnecessary field

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
