### PR TITLE
[Fairground] Add Gallery card type

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -528,6 +528,10 @@ message Card {
     CARD_TYPE_HIGHLIGHT = 10;
 
     CARD_TYPE_NAVIGATION = 11;
+    /**
+     * A card for a gallery item.
+     */
+    CARD_TYPE_GALLERY = 12;
   }
   CardType type = 1;
   /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -165,6 +165,10 @@
               {
                 "name": "CARD_TYPE_NAVIGATION",
                 "integer": 11
+              },
+              {
+                "name": "CARD_TYPE_GALLERY",
+                "integer": 12
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are building media cards in the new design as part of the homepage redesign project.

Here is an example of the new gallery card design.  An article card design is placed beside it for comparison.

| Gallery card | Article card |
| --- | --- |
| <img width="300px" src="https://github.com/user-attachments/assets/34ced450-a8c8-4470-b76c-85e7adf3e24d" /> | <img width="300px" src="https://github.com/user-attachments/assets/beeb0c5f-6715-4a86-897d-d2fff097d0c8" /> |

This pull request adds a new card type `CARD_TYPE_GALLERY` for gallery cards so that the native apps can render a card in gallery card design for gallery items.

