### PR TITLE
Add a vertical spacing property in lists and collections

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -137,6 +137,8 @@ message Collection {
    * The default aspect ratio for trail images in this collection.
    */
   optional ImageAspectRatio preferred_image_aspect_ratio = 23;
+
+  optional bool tighten_vertical_spacing = 24;
 }
 
 /**
@@ -216,6 +218,8 @@ message List {
   optional google.protobuf.Timestamp last_updated_date = 17;
 
   optional Header header = 18;
+
+  optional bool tighten_vertical_spacing = 19;
 }
 
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -578,6 +578,12 @@
                 "name": "preferred_image_aspect_ratio",
                 "type": "ImageAspectRatio",
                 "optional": true
+              },
+              {
+                "id": 24,
+                "name": "tighten_vertical_spacing",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -722,6 +728,12 @@
                 "id": 18,
                 "name": "header",
                 "type": "Header",
+                "optional": true
+              },
+              {
+                "id": 19,
+                "name": "tighten_vertical_spacing",
+                "type": "bool",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a field `tighten_vertical_spacing` on the Collection and List model, which will be used to make the gaps smaller for layouts that produce small and xsmall cards

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
