### PR TITLE
Add is_live_video bool to video message

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -349,6 +349,7 @@ message Video {
   optional string youtube_id = 8;
   optional int32 duration_in_seconds = 9;
   optional Image poster_image = 10;
+  bool is_live_video = 11;
 }
 
 message Audio {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1053,6 +1053,11 @@
                 "name": "poster_image",
                 "type": "Image",
                 "optional": true
+              },
+              {
+                "id": 11,
+                "name": "is_live_video",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Part of this [fronts and curation ticket](https://trello.com/c/3AplJH4V/874-mss-live-timestamp-on-videos). This requires a [change in MAPI](https://github.com/guardian/mobile-apps-api/pull/3480) and the data model, hence this PR. 

This just adds an "is_live_video" boolean which will get used by the apps to indicate if they should show a "Live" pill in the place of the video duration. 

From testing with the MAPI PR, this seems to be working as intended. 