### PR TITLE
add media pill

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -332,6 +332,12 @@ enum MediaType {
 message MediaPill {
   string name = 1;
   string icon = 2;
+  /*
+    The detail varies depending on the type of pill:
+    for a video or podcast, it's the duration,
+    for a gallery it's the number of images,
+    for a newsletter it's the frequency
+  */
   string detail = 3;
 }
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -329,6 +329,12 @@ enum MediaType {
   MEDIA_TYPE_IMAGE = 3;
 }
 
+message MediaPill {
+  string name = 1;
+  string icon = 2;
+  string detail = 3;
+}
+
 message Image {
   optional string alt_text = 1;
   optional string caption = 2;
@@ -502,6 +508,9 @@ message Article {
 
   // Only applicable to navigational card
   optional FollowUp follow_up = 39;
+
+  // The pill details that media cards should display.
+  optional MediaPill media_pill = 40;
 }
 
 message Card {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -953,6 +953,26 @@
             ]
           },
           {
+            "name": "MediaPill",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "icon",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "detail",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "Image",
             "fields": [
               {
@@ -1499,6 +1519,12 @@
                 "id": 39,
                 "name": "follow_up",
                 "type": "FollowUp",
+                "optional": true
+              },
+              {
+                "id": 40,
+                "name": "media_pill",
+                "type": "MediaPill",
                 "optional": true
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Part of this fronts and curation [ticket to add media pills](https://trello.com/c/9BtM4i6z/1107-new-media-card-pills-mss)

We've agreed with the apps developers to add this optional field to an article which will contain an object with the following strings: the name of the media pill (e.g. video, gallery), the relevant icon to use and some further text detail - the detail itself will vary depending on the type of pill: for a video or podcast, it'll be the duration, for a gallery it's the number of images, and in the future for a newsletter this'll be the frequency. 

## How to test

I'm using the preview release with [this MAPI branch](https://github.com/guardian/mobile-apps-api/pull/3599), and could see the field appearing in the json for the card in a collection when appropriate:

![image](https://github.com/user-attachments/assets/6e3a8efd-d479-43d9-87af-c7e07ed02782)



## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
