### PR TITLE
Extend CardSize to include a CARD_SIZE_X_LARGE_HORIZONTAL variant

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -701,7 +701,9 @@ message Card {
     CARD_SIZE_LARGE_HORIZONTAL = 6;
     CARD_SIZE_X_LARGE = 7;
     CARD_SIZE_HIGHLIGHTS = 8;
+    CARD_SIZE_X_LARGE_HORIZONTAL = 9;
   }
+
 
   optional CardSize card_size = 44;
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -704,7 +704,6 @@ message Card {
     CARD_SIZE_X_LARGE_HORIZONTAL = 9;
   }
 
-
   optional CardSize card_size = 44;
 
   optional int32 boost_level = 45;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -269,6 +269,10 @@
               {
                 "name": "CARD_SIZE_HIGHLIGHTS",
                 "integer": 8
+              },
+              {
+                "name": "CARD_SIZE_X_LARGE_HORIZONTAL",
+                "integer": 9
               }
             ]
           },


### PR DESCRIPTION
## What does this change?
Extend CardSize to include a CARD_SIZE_X_LARGE_HORIZONTAL variant. This will be used by the immersive feature card on tablet; a full width card with a full 5:3 image background and overlay. 

This can be tested by using the preview version of this release in a local version of MAPI with branch https://github.com/guardian/mobile-apps-api/pull/3615 and see that the card size is used correctly on the blueprint model.

![Screenshot 2025-04-09 at 17 44 17](https://github.com/user-attachments/assets/9f481403-12c8-4039-b4e0-6e48ce5d0572)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
