### PR TITLE
Add nav cards enum

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -722,8 +722,17 @@ message Card {
    * Control what font weight to use for the headline.
    */
   optional FontWeight headline_weight = 48;
+
+  optional NavCardType nav_card_type = 49;
 }
 
+enum NavCardType {
+    Unspecified = 0;
+    News = 1;
+    Sport = 2;
+    Lifestyle = 3;
+    Narrative = 4;
+}
 enum TopBorderStyle {
   TOP_BORDER_STYLE_UNSPECIFIED = 0;
   TOP_BORDER_STYLE_HIDDEN = 1;

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -727,12 +727,13 @@ message Card {
 }
 
 enum NavCardType {
-    Unspecified = 0;
-    News = 1;
-    Sport = 2;
-    Lifestyle = 3;
-    Narrative = 4;
+  NAV_CARD_TYPE_UNSPECIFIED = 0;
+  NAV_CARD_TYPE_NEWS = 1;
+  NAV_CARD_TYPE_SPORT = 2;
+  NAV_CARD_TYPE_LIFESTYLE = 3;
+  NAV_CARD_TYPE_NARRATIVE = 4;
 }
+
 enum TopBorderStyle {
   TOP_BORDER_STYLE_UNSPECIFIED = 0;
   TOP_BORDER_STYLE_HIDDEN = 1;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -277,6 +277,30 @@
             ]
           },
           {
+            "name": "NavCardType",
+            "enum_fields": [
+              {
+                "name": "Unspecified"
+              },
+              {
+                "name": "News",
+                "integer": 1
+              },
+              {
+                "name": "Sport",
+                "integer": 2
+              },
+              {
+                "name": "Lifestyle",
+                "integer": 3
+              },
+              {
+                "name": "Narrative",
+                "integer": 4
+              }
+            ]
+          },
+          {
             "name": "TopBorderStyle",
             "enum_fields": [
               {
@@ -1701,6 +1725,12 @@
                 "id": 48,
                 "name": "headline_weight",
                 "type": "FontWeight",
+                "optional": true
+              },
+              {
+                "id": 49,
+                "name": "nav_card_type",
+                "type": "NavCardType",
                 "optional": true
               }
             ],

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -280,22 +280,22 @@
             "name": "NavCardType",
             "enum_fields": [
               {
-                "name": "Unspecified"
+                "name": "NAV_CARD_TYPE_UNSPECIFIED"
               },
               {
-                "name": "News",
+                "name": "NAV_CARD_TYPE_NEWS",
                 "integer": 1
               },
               {
-                "name": "Sport",
+                "name": "NAV_CARD_TYPE_SPORT",
                 "integer": 2
               },
               {
-                "name": "Lifestyle",
+                "name": "NAV_CARD_TYPE_LIFESTYLE",
                 "integer": 3
               },
               {
-                "name": "Narrative",
+                "name": "NAV_CARD_TYPE_NARRATIVE",
                 "integer": 4
               }
             ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a NavCardType enum property, so that this can be used by the native devs to determine which visual designs to apply to which card

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
