### PR TITLE
Support self-hosted, looping videos

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -350,6 +350,12 @@ message Image {
   optional int32 width = 7;
 }
 
+enum Platform {
+  PLATFORM_UNSPECIFIED = 0;
+  PLATFORM_YOUTUBE = 1;
+  PLATFORM_URL = 2;
+}
+
 message Video {
   optional string alt_text = 1;
   optional string caption = 2;
@@ -358,10 +364,13 @@ message Video {
   optional string orientation = 5;
   string url = 6;
   optional int32 width = 7;
-  optional string youtube_id = 8;
+  optional string youtube_id = 8 [deprecated = true];
   optional int32 duration_in_seconds = 9;
   optional Image poster_image = 10;
   bool is_live_video = 11;
+  optional string video_id = 12;
+  optional Platform platform = 13;
+  bool is_looping = 14;
 }
 
 message Audio {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -97,6 +97,22 @@
             ]
           },
           {
+            "name": "Platform",
+            "enum_fields": [
+              {
+                "name": "PLATFORM_UNSPECIFIED"
+              },
+              {
+                "name": "PLATFORM_YOUTUBE",
+                "integer": 1
+              },
+              {
+                "name": "PLATFORM_URL",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "TitleStyle",
             "enum_fields": [
               {
@@ -1088,7 +1104,13 @@
                 "id": 8,
                 "name": "youtube_id",
                 "type": "string",
-                "optional": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 9,
@@ -1105,6 +1127,23 @@
               {
                 "id": 11,
                 "name": "is_live_video",
+                "type": "bool"
+              },
+              {
+                "id": 12,
+                "name": "video_id",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "platform",
+                "type": "Platform",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "is_looping",
                 "type": "bool"
               }
             ]


### PR DESCRIPTION
## What does this change?
This change extends the blueprint `Video` protobuf model to support both YouTube-hosted and self-hosted videos. It also introduces support for looping videos. This change is required to enable Fronts to support YouTube atoms alongside self-hosted video content.

The changes are as follows: 
- Deprecated `youtube_id` in favour of a more general-purpose `video_id` field to allow support for multiple video platforms.
- Introduced platform field of type `Platform` enum, which currently supports:
`PLATFORM_YOUTUBE`
`PLATFORM_URL`
Any other platform is considered unsupported and typed as `PLATFORM_UNSUPPORTED`.
- Added `is_looping field` to indicate whether the video should loop when played.

Note we will use the `url` field to supply the video source to the player.
