### PR TITLE
Add support for condensed palette light and dark on the card model.

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -735,6 +735,13 @@ message Card {
   optional NavCardType nav_card_type = 49;
 
   optional bool should_hide_image = 50;
+
+  /**
+   * Provide a separate palette for Android's condensed view.
+   */
+  optional Palette condensed_palette_light = 51;
+  optional Palette condensed_palette_dark = 52;
+
 }
 
 enum NavCardType {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1777,6 +1777,18 @@
                 "name": "should_hide_image",
                 "type": "bool",
                 "optional": true
+              },
+              {
+                "id": 51,
+                "name": "condensed_palette_light",
+                "type": "Palette",
+                "optional": true
+              },
+              {
+                "id": 52,
+                "name": "condensed_palette_dark",
+                "type": "Palette",
+                "optional": true
               }
             ],
             "reserved_ids": [


### PR DESCRIPTION
This is of type palette and can be used by the android app when the user is in condensed view mode.

## What does this change?
Add support for condensed palette light and dark on the card model.

This is of type palette and can be used by the android app when the user is in condensed view mode.
