### PR TITLE
Add should_hide_image flag to Card model

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -733,6 +733,8 @@ message Card {
   optional FontWeight headline_weight = 48;
 
   optional NavCardType nav_card_type = 49;
+
+  optional bool should_hide_image = 50;
 }
 
 enum NavCardType {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1771,6 +1771,12 @@
                 "name": "nav_card_type",
                 "type": "NavCardType",
                 "optional": true
+              },
+              {
+                "id": 50,
+                "name": "should_hide_image",
+                "type": "bool",
+                "optional": true
               }
             ],
             "reserved_ids": [


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Part of this [ticket](https://trello.com/c/bTGireuU/1227-display-series-img-mss) and used in this MAPI [PR](https://github.com/guardian/mobile-apps-api/pull/3803). 

Adds an optional boolean to a card which we'll use to indicate if whether or not an image should show on. a podcast card. The client will first attempt to read the podcastSeriesImage for these cards and will fall back to the article image.

## How to test

Run the associated MAPI branch and check the JSON response for various articles. If it's a small podcast card, the value should be set to true.


