### PR TITLE
Control the display of UI controls on videos

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -386,9 +386,9 @@ message Video {
   bool show_subtitles = 18;
   VideoOverlayPosition overlay_position = 19;
   /*
-   * Allow users to mute / unmuate the video
+   * Allow users to unmute the video
    */
-  bool allow_mute = 20;
+  bool support_audio = 20;
   /*
    * Allow users to navigate the video for example
    * through a scrub bar

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -399,10 +399,14 @@ message Video {
    */
   bool allow_fullscreen = 22;
   /*
+   * Display timestamp on the player
+   */
+  bool show_timestamp = 23;
+  /*
    * Allow users to share the video via the platform's
    * sharing capability
    */
-  bool allow_sharing = 23;
+  bool allow_sharing = 24;
 }
 
 message Audio {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -385,6 +385,24 @@ message Video {
   bool show_progress_bar = 17;
   bool show_subtitles = 18;
   VideoOverlayPosition overlay_position = 19;
+  /*
+   * Allow users to mute / unmuate the video
+   */
+  bool allow_mute = 20;
+  /*
+   * Allow users to navigate the video for example
+   * through a scrub bar
+   */
+  bool allow_seeking = 21;
+  /*
+   * Allow users to expand the video full screen
+   */
+  bool allow_fullscreen = 22;
+  /*
+   * Allow users to share the video via the platform's
+   * sharing capability
+   */
+  bool allow_sharing = 23;
 }
 
 message Audio {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1220,6 +1220,11 @@
               },
               {
                 "id": 23,
+                "name": "show_timestamp",
+                "type": "bool"
+              },
+              {
+                "id": 24,
                 "name": "allow_sharing",
                 "type": "bool"
               }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1205,7 +1205,7 @@
               },
               {
                 "id": 20,
-                "name": "allow_mute",
+                "name": "support_audio",
                 "type": "bool"
               },
               {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1202,6 +1202,26 @@
                 "id": 19,
                 "name": "overlay_position",
                 "type": "VideoOverlayPosition"
+              },
+              {
+                "id": 20,
+                "name": "allow_mute",
+                "type": "bool"
+              },
+              {
+                "id": 21,
+                "name": "allow_seeking",
+                "type": "bool"
+              },
+              {
+                "id": 22,
+                "name": "allow_fullscreen",
+                "type": "bool"
+              },
+              {
+                "id": 23,
+                "name": "allow_sharing",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds the following new property to the Video model, which allows MAPI to control which UI function is visible in the video player.
`support_audio` - show mute/unmute button so users can unmute
`allow_seeking` - show a scrub bar to allow users to navigate
`allow_fullscreen` - show expand/restore button
`show_timestamp` - show the timestamp at which the video is playing, ususally next to the progress bar / scrub bar.
`allow_sharing` - show share button

## How has this change been tested?

These properties are new so they are not used by the apps at the moment.  No impact on the production apps is expected.

## How can we measure success?

Make progress to the development of the new video player on apps.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213967418588607