### PR TITLE
Add tracking ID to videos

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -407,6 +407,11 @@ message Video {
    * sharing capability
    */
   bool allow_sharing = 24;
+  /**
+   * Provide meta data for the apps to send tracking data over
+   * this video object
+   */
+  EventTracking tracking = 25;
 }
 
 message Audio {
@@ -971,6 +976,11 @@ message Permutive {
   repeated string keywords = 6;
   optional google.protobuf.Timestamp published_at = 7;
   optional string series = 8;
+}
+
+/** For sending users' action tracking data to Ophan */
+message EventTracking {
+  string component_id = 1;
 }
 
 /** For some articles we return commissioning desk tracking (aka BasicTag)

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1227,6 +1227,11 @@
                 "id": 24,
                 "name": "allow_sharing",
                 "type": "bool"
+              },
+              {
+                "id": 25,
+                "name": "tracking",
+                "type": "EventTracking"
               }
             ]
           },
@@ -2121,6 +2126,16 @@
                 "name": "series",
                 "type": "string",
                 "optional": true
+              }
+            ]
+          },
+          {
+            "name": "EventTracking",
+            "fields": [
+              {
+                "id": 1,
+                "name": "component_id",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request defines a new message for tracking data on videos and adds a new property in this message type to the `Video` model. We've added a tracking ID as the only property to the tracking data message, and we can further refine the message type later.

## How has this change been tested?

These properties are new so they are not used by the apps at the moment. No impact on the production apps is expected.

## How can we measure success?

Allow tracking ID to be generated from server side to make it easy to change and make sure it will be consistent across iOS / Android. Make progress to the development of the new video player on apps.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214150807647854