### PR TITLE
Add property on auto-hiding controls in video player

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -412,6 +412,10 @@ message Video {
    * this video object
    */
   EventTracking tracking = 25;
+  /**
+   * Auto hide UI controls on player
+   */
+  bool auto_hide_controls = 26;
 }
 
 message Audio {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1232,6 +1232,11 @@
                 "id": 25,
                 "name": "tracking",
                 "type": "EventTracking"
+              },
+              {
+                "id": 26,
+                "name": "auto_hide_controls",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a new property to the Video model, which allows MAPI to control whether the apps should auto-hide UI controls in video player.

## How has this change been tested?

These properties are new so they are not used by the apps at the moment. No impact on the production apps is expected.

## How can we measure success?

Support the development of the new video player on apps.