### PR TITLE
Add new ability to prevent the user from removing some thrashers.

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -171,7 +171,7 @@ message FollowUp {
 message Thrasher {
   string uri = 1;
   // Determines if the thrasher should be removable by the user.
-  optional bool requiered = 2; 
+  optional bool required = 2; 
 }
 
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -171,8 +171,7 @@ message FollowUp {
 message Thrasher {
   string uri = 1;
   // Determines if the thrasher should be removable by the user.
-  // If not provided, we assume true.
-  optional bool removeable = 2; 
+  optional bool requiered = 2; 
 }
 
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -170,6 +170,9 @@ message FollowUp {
  */
 message Thrasher {
   string uri = 1;
+  // Determines if the thrasher should be removable by the user.
+  // If not provided, we assume true.
+  optional bool removeable = 2; 
 }
 
 

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -682,7 +682,7 @@
               },
               {
                 "id": 2,
-                "name": "requiered",
+                "name": "required",
                 "type": "bool",
                 "optional": true
               }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -679,6 +679,12 @@
                 "id": 1,
                 "name": "uri",
                 "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "requiered",
+                "type": "bool",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a new option that allows the server to determine whether a thrasher is removable. This will allow us to control if the "Remove this" button is shown below thrashers. This is an example of where we would want a thrasher to not be removable. 
<img width="1206" height="2622" alt="simulator_screenshot_0B213CD9-E916-4573-9E24-4323848959EB" src="https://github.com/user-attachments/assets/3b943c1d-8d00-4b76-a5a7-da894f27c171" />

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist, and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
