### PR TITLE
Add fields to puzzle model

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -606,6 +606,8 @@ message Puzzle {
   optional PuzzleType type = 1;
   optional PuzzleSubType sub_type = 2;
   optional string uri = 3;
+  optional string id = 4;
+  optional string title = 5;
 }
 
 message Card {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1803,6 +1803,18 @@
                 "name": "uri",
                 "type": "string",
                 "optional": true
+              },
+              {
+                "id": 4,
+                "name": "id",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "title",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
Add id and title fields to puzzle model. These should have been included in [Add puzzles model to Blueprint schema](https://github.com/guardian/mobile-apps-api-models/pull/197) 

### What Changed
- Added optional field Puzzle.id as field number 4 in blueprint.proto.
- Added optional field Puzzle.title as field number 5 in blueprint.proto.
- Updated lock metadata in proto.lock