### PR TITLE
Add AB test info to event tracking

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -1031,8 +1031,17 @@ message EventTracking {
   repeated AbTestInfo ab_tests = 2;
 }
 
+/** Information about active A/B tests associated with this video. */
 message AbTestInfo {
+  /** the name of the experiment. It should be used to populate 
+   * the name field of AbTest object in Ophan's event model.
+   */
   string name = 1;
+
+  /** the variant of the experiment this response is showing. 
+   * It should be used to populate the variant name field of 
+   * AbTest object in Ophan's event model.
+   */
   string variant = 2; 
 }
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -1028,6 +1028,12 @@ message Permutive {
 /** For sending users' action tracking data to Ophan */
 message EventTracking {
   string component_id = 1;
+  repeated AbTestInfo ab_tests = 2;
+}
+
+message AbTestInfo {
+  string name = 1;
+  string variant = 2; 
 }
 
 /** For some articles we return commissioning desk tracking (aka BasicTag)

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -2272,6 +2272,27 @@
                 "id": 1,
                 "name": "component_id",
                 "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ab_tests",
+                "type": "AbTestInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "AbTestInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "variant",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are looking to run A/B tests on video player UI on the front and want to add support for A/B tests in the event tracking message, that is part of a "Video" object in Blueprint responses.

This pull requests add new properties to the event tracking message for 
- the name of the A/B test we are running on the video.
- the variant UI it belongs to.

## How has this change been tested?

These properties are new so they are not used by the apps at the moment. No impact on the production apps is expected.

## How can we measure success?

Support the A/B testing of the new video player on apps.