### PR TITLE
Add aspect ratio to Video model

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -418,6 +418,10 @@ message Video {
    * Auto hide UI controls on player
    */
   bool auto_hide_controls = 26;
+  /**
+   * Aspect ratio of the video
+   */
+  optional string aspect_ratio = 27;
 }
 
 message Audio {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1327,6 +1327,12 @@
                 "id": 26,
                 "name": "auto_hide_controls",
                 "type": "bool"
+              },
+              {
+                "id": 27,
+                "name": "aspect_ratio",
+                "type": "string",
+                "optional": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request adds a new property "aspect_ratio" to Video model as the width and height are not always available. This property helps the apps to play the video in the right dimension.

It may have the aspect ratio in this format - e.g. "4:5", "16:9"

## How has this change been tested?

No apps are using the new property yet so it should not affect the production apps.

## How can we measure success?

The apps can play videos in m3u8 format using the correct dimension without relying on the hack where we put the values from the aspect ratio into the "width" and "height" fields. 