### PR TITLE
Add tag references and pa football team reference to Tag model

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -1,7 +1,7 @@
 {
   "definitions": [
     {
-      "protopath": "blueprint.proto",
+      "protopath": "proto:/:blueprint.proto",
       "def": {
         "enums": [
           {

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -139,6 +139,8 @@ message Collection {
   optional ImageAspectRatio preferred_image_aspect_ratio = 23;
 
   optional bool tighten_vertical_spacing = 24;
+
+  optional TagReferences references = 25;
 }
 
 /**
@@ -171,7 +173,7 @@ message FollowUp {
 message Thrasher {
   string uri = 1;
   // Determines if the thrasher should be removable by the user.
-  optional bool required = 2; 
+  optional bool required = 2;
 }
 
 
@@ -278,6 +280,7 @@ message LayoutAgnosticCollection {
   optional string tracking_id = 7;
 
   optional Image image = 8;
+  optional TagReferences references = 9;
 }
 
 /************************* SHARED *************************/
@@ -603,8 +606,8 @@ enum PuzzleSubType {
   PUZZLE_SUB_TYPE_KILLER_SUDOKU = 10;
 }
 
-// For puzzle types that do not use sub types (e.g., WORDIPLY, WORD_WHEEL, 
-// ON_THE_BALL, FILM_REVEAL), set sub_type = PUZZLE_SUB_TYPE_UNSPECIFIED. 
+// For puzzle types that do not use sub types (e.g., WORDIPLY, WORD_WHEEL,
+// ON_THE_BALL, FILM_REVEAL), set sub_type = PUZZLE_SUB_TYPE_UNSPECIFIED.
 // This is the idiomatic way to represent "no sub type" in proto3 enums.
 message Puzzle {
   optional PuzzleType type = 1;
@@ -998,6 +1001,7 @@ message MyGuardianFollow {
   string id = 1;
   string web_title = 2;
   FollowType type = 3;
+  optional TagReferences references = 4;
 }
 
 
@@ -1037,16 +1041,16 @@ message EventTracking {
 
 /** Information about active A/B tests associated with this video. */
 message AbTestInfo {
-  /** the name of the experiment. It should be used to populate 
+  /** the name of the experiment. It should be used to populate
    * the name field of AbTest object in Ophan's event model.
    */
   string name = 1;
 
-  /** the variant of the experiment this response is showing. 
-   * It should be used to populate the variant name field of 
+  /** the variant of the experiment this response is showing.
+   * It should be used to populate the variant name field of
    * AbTest object in Ophan's event model.
    */
-  string variant = 2; 
+  string variant = 2;
 }
 
 /** For some articles we return commissioning desk tracking (aka BasicTag)
@@ -1270,4 +1274,8 @@ message Match {
    * stats and topic for notification.
    */
   optional string match_info_uri = 7;
+}
+
+message TagReferences {
+  optional string pa_football_team = 1;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add a TagReferences message to the protobuf schema with an optional `pa_football_team` field. This is referenced from Collection, LayoutAgnosticCollection, and MyGuardianFollow, allowing native clients to correlate a CAPI football tag with its corresponding PA team ID directly from the blueprint response,  without requiring a separate lookup.

## How has this change been tested?
Tested the snapshot version in MAPI with [this PR ](https://github.com/guardian/mobile-apps-api/pull/4284)
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->


