### PR TITLE
Add Election card type

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -664,6 +664,10 @@ message Card {
      * A card for a puzzle item.
      */
     CARD_TYPE_PUZZLE = 13;
+    /**
+     * A card for a election results tracker.
+     */
+    CARD_TYPE_ELECTION = 14;
   }
   CardType type = 1;
   /**
@@ -836,6 +840,11 @@ message Card {
   optional Palette condensed_palette_dark = 52;
 
   optional Puzzle puzzle = 53;
+
+  /**
+   * Endpoint to call to get data needed to display event graphics in this card.
+   */
+  optional string event_graphics_data_uri = 54;
 
 }
 

--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -840,12 +840,6 @@ message Card {
   optional Palette condensed_palette_dark = 52;
 
   optional Puzzle puzzle = 53;
-
-  /**
-   * Endpoint to call to get data needed to display event graphics in this card.
-   */
-  optional string event_graphics_data_uri = 54;
-
 }
 
 enum NavCardType {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -289,6 +289,10 @@
               {
                 "name": "CARD_TYPE_PUZZLE",
                 "integer": 13
+              },
+              {
+                "name": "CARD_TYPE_ELECTION",
+                "integer": 14
               }
             ]
           },
@@ -2034,6 +2038,12 @@
                 "id": 53,
                 "name": "puzzle",
                 "type": "Puzzle",
+                "optional": true
+              },
+              {
+                "id": 54,
+                "name": "event_graphics_data_uri",
+                "type": "string",
                 "optional": true
               }
             ],

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -2039,12 +2039,6 @@
                 "name": "puzzle",
                 "type": "Puzzle",
                 "optional": true
-              },
-              {
-                "id": 54,
-                "name": "event_graphics_data_uri",
-                "type": "string",
-                "optional": true
               }
             ],
             "reserved_ids": [


### PR DESCRIPTION
## What does this change?
Adds new election card type and eventGraphicsDataUri for displaying native election tracker components, with a uri for where to fetch the data from.

Ticket: https://github.com/guardian/eventkit-mission/issues/78

## How has this change been tested?
Deployed this to code MAPI as a part of this ticket https://github.com/guardian/eventkit-mission/issues/79

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
