### PR TITLE
Add new field at card level for web fallback

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -543,6 +543,7 @@ message Article {
   optional RenderingPlatformSupport rendered_item_beta = 25;
   // Quoted headline shown for a card if selected in the fronts tool.
   optional bool show_quoted_headline = 26;
+
   // Only applicable to cards that display web content (e.g. snap links)
   optional string web_content_uri = 27;
   Tracking tracking = 28;
@@ -727,7 +728,18 @@ message Card {
    */
   optional bool compact = 4;
   repeated Article sublinks = 5;
+  
+  /**
+   * HTML string containing a blob of HTML to render if an unknown card type or
+   * error rendering.
+  */
   optional string html_fallback = 6;
+
+  /**
+   * URL of web content to show if unknown card type or error rendering.
+  */
+  optional string uri_fallback = 13;
+  
   /**
    * Individual cards can be branded and not be part of a branded container.
    * Cards that are branded tend to show the sponsor logo and should be

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1990,6 +1990,12 @@
                 "optional": true
               },
               {
+                "id": 13,
+                "name": "uri_fallback",
+                "type": "string",
+                "optional": true
+              },
+              {
                 "id": 7,
                 "name": "branding",
                 "type": "Branding",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds new field at card level for web fallback uri.

Adds comment explaining that html_fallback is intended for blob of actual HTML not a url to fetch HTML from somewhere.

## How has this change been tested?
This change can be tested on a MAPI code branch once MAPI updates to this schema version, then the Android and iOS apps will have to create PRs to read this fallback.

## How can we measure success?

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
