### PR TITLE
Make puzzle id none optional to match the iOS changes

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -543,7 +543,6 @@ message Article {
   optional RenderingPlatformSupport rendered_item_beta = 25;
   // Quoted headline shown for a card if selected in the fronts tool.
   optional bool show_quoted_headline = 26;
-
   // Only applicable to cards that display web content (e.g. snap links)
   optional string web_content_uri = 27;
   Tracking tracking = 28;
@@ -641,9 +640,11 @@ message Puzzle {
   reserved "type";
   reserved 2;
   reserved "sub_type";
-  
+  /**
+   Puzzle URI
+   */
   optional string uri = 3;
-  optional string id = 4;
+  string id = 4;
   optional string title = 5;
   
   optional Palette palette_light = 6;

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -1897,8 +1897,7 @@
               {
                 "id": 4,
                 "name": "id",
-                "type": "string",
-                "optional": true
+                "type": "string"
               },
               {
                 "id": 5,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This makes the Puzzle ID required to match the iOS changes. This was changed in the Swift models but not brought back to this repo. We've also added a comment to work around a limitation on the iOS parser that was creating issues.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
