### PR TITLE
Add `Collection.puzzle_archive_types` property

### DIFF
--- a/proto/blueprint.proto
+++ b/proto/blueprint.proto
@@ -141,6 +141,14 @@ message Collection {
   optional bool tighten_vertical_spacing = 24;
 
   optional TagReferences references = 25;
+
+  /**
+   * Ordered list of puzzle types that are available in this collection. This
+   * is used to display the puzzle types in the archive menu for this
+   * collection.
+   * If this list is empty, the archive link should not be displayed.
+   */
+  repeated PuzzleTypes puzzle_archive_types = 26;
 }
 
 /**

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -822,6 +822,12 @@
                 "name": "references",
                 "type": "TagReferences",
                 "optional": true
+              },
+              {
+                "id": 26,
+                "name": "puzzle_archive_types",
+                "type": "PuzzleTypes",
+                "is_repeated": true
               }
             ]
           },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new property - `puzzle_archive_type` - to the `Collection` model.

This is used to provide the list of puzzle types that are present in the collection. It will allow the clients to populate an archive link dropdown for each collection.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This MAPI PR depends on this change: https://github.com/guardian/mobile-apps-api/pull/4331

